### PR TITLE
feat: photo intake and app storage

### DIFF
--- a/__tests__/photoUtils.test.ts
+++ b/__tests__/photoUtils.test.ts
@@ -1,0 +1,25 @@
+import { getRemainingPhotoSlots, resolvePhotoAddLimit, MAX_FREE_PHOTOS_PER_REPORT } from '@/src/features/photos/photoUtils';
+
+describe('photoUtils', () => {
+  test('getRemainingPhotoSlots respects free limit', () => {
+    expect(getRemainingPhotoSlots(false, 0)).toBe(MAX_FREE_PHOTOS_PER_REPORT);
+    expect(getRemainingPhotoSlots(false, 9)).toBe(1);
+    expect(getRemainingPhotoSlots(false, 10)).toBe(0);
+  });
+
+  test('getRemainingPhotoSlots is infinite for Pro', () => {
+    expect(getRemainingPhotoSlots(true, 10)).toBe(Number.POSITIVE_INFINITY);
+  });
+
+  test('resolvePhotoAddLimit caps additions for Free', () => {
+    const result = resolvePhotoAddLimit(false, 9, 3);
+    expect(result.allowedCount).toBe(1);
+    expect(result.blocked).toBe(true);
+  });
+
+  test('resolvePhotoAddLimit allows all for Pro', () => {
+    const result = resolvePhotoAddLimit(true, 9, 3);
+    expect(result.allowedCount).toBe(3);
+    expect(result.blocked).toBe(false);
+  });
+});

--- a/src/core/i18n/i18n.ts
+++ b/src/core/i18n/i18n.ts
@@ -1,3 +1,4 @@
+import { useMemo } from 'react';
 import { create } from 'zustand';
 import { persist, createJSONStorage } from 'zustand/middleware';
 import AsyncStorage from '@react-native-async-storage/async-storage';
@@ -120,8 +121,11 @@ const useI18nStore = create<I18nState>()(
 export function useTranslation() {
   const lang = useI18nStore((s) => s.lang);
   const setLang = useI18nStore((s) => s.setLang);
-  const t = (key: TranslationKey) => dictionaries[lang][key] ?? baseEn[key] ?? key;
-  return { t, lang, setLang };
+  const dict = useMemo(
+    () => ({ ...baseEn, ...dictionaries[lang] }),
+    [lang],
+  );
+  return { t: dict, lang, setLang };
 }
 
 export function setLang(lang: Lang) {

--- a/src/core/i18n/locales/de.ts
+++ b/src/core/i18n/locales/de.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/en.ts
+++ b/src/core/i18n/locales/en.ts
@@ -238,6 +238,15 @@ const baseEn = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export type TranslationKey = keyof typeof baseEn;

--- a/src/core/i18n/locales/es.ts
+++ b/src/core/i18n/locales/es.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/fr.ts
+++ b/src/core/i18n/locales/fr.ts
@@ -242,6 +242,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/hi.ts
+++ b/src/core/i18n/locales/hi.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/id.ts
+++ b/src/core/i18n/locales/id.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/it.ts
+++ b/src/core/i18n/locales/it.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/ja.ts
+++ b/src/core/i18n/locales/ja.ts
@@ -211,6 +211,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/ko.ts
+++ b/src/core/i18n/locales/ko.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/nl.ts
+++ b/src/core/i18n/locales/nl.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/pt.ts
+++ b/src/core/i18n/locales/pt.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/ru.ts
+++ b/src/core/i18n/locales/ru.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/sv.ts
+++ b/src/core/i18n/locales/sv.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/th.ts
+++ b/src/core/i18n/locales/th.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/tr.ts
+++ b/src/core/i18n/locales/tr.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/vi.ts
+++ b/src/core/i18n/locales/vi.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/zhHans.ts
+++ b/src/core/i18n/locales/zhHans.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/core/i18n/locales/zhHant.ts
+++ b/src/core/i18n/locales/zhHant.ts
@@ -198,6 +198,15 @@ const dict = {
   addressLabel: 'Address',
   addressPlaceholder: 'Enter address...',
   obtaining: 'Obtaining...',
+  photosLabel: 'Photos',
+  addFromCamera: 'Camera',
+  addFromLibrary: 'Library',
+  photoLimitHint: 'Free plan allows up to {max} photos per report.',
+  photoLimitTitle: 'Photo limit reached',
+  photoLimitBody: 'Free plan allows up to {max} photos per report.',
+  photoPermissionDenied: 'Photo permission denied',
+  photoAddFailed: 'Failed to add photo',
+  photoEmpty: 'No photos yet.',
 };
 
 export default dict;

--- a/src/features/photos/photoUtils.ts
+++ b/src/features/photos/photoUtils.ts
@@ -1,0 +1,19 @@
+export const MAX_FREE_PHOTOS_PER_REPORT = 10;
+
+export const getRemainingPhotoSlots = (isPro: boolean, currentCount: number) => {
+  if (isPro) return Number.POSITIVE_INFINITY;
+  return Math.max(0, MAX_FREE_PHOTOS_PER_REPORT - currentCount);
+};
+
+export const resolvePhotoAddLimit = (
+  isPro: boolean,
+  currentCount: number,
+  addCount: number,
+) => {
+  const remaining = getRemainingPhotoSlots(isPro, currentCount);
+  const allowedCount = Math.max(0, Math.min(addCount, remaining));
+  return {
+    allowedCount,
+    blocked: allowedCount < addCount,
+  };
+};

--- a/src/services/photoService.ts
+++ b/src/services/photoService.ts
@@ -1,0 +1,156 @@
+import * as ImagePicker from 'expo-image-picker';
+import * as FileSystem from 'expo-file-system';
+import * as ImageManipulator from 'expo-image-manipulator';
+
+import type { Photo } from '@/src/types/models';
+import { listPhotosByReport, createPhoto } from '@/src/db/photoRepository';
+import { resolvePhotoAddLimit } from '@/src/features/photos/photoUtils';
+
+const PHOTO_DIR_ROOT = 'repolog/reports';
+const MAX_EDGE = 1600;
+const JPEG_QUALITY = 0.85;
+
+type AddPhotoResult = {
+  photos: Photo[];
+  blocked: boolean;
+  canceled: boolean;
+  reason?: 'permission' | 'error';
+};
+
+const getDocumentDirectory = () =>
+  FileSystem.Paths?.document?.uri ?? (FileSystem as unknown as { documentDirectory?: string }).documentDirectory;
+
+const ensureReportPhotoDir = async (reportId: string) => {
+  const documentDirectory = getDocumentDirectory();
+  if (!documentDirectory) {
+    throw new Error('Document directory not available.');
+  }
+  const dir = `${documentDirectory}${PHOTO_DIR_ROOT}/${reportId}/photos/`;
+  await FileSystem.makeDirectoryAsync(dir, { intermediates: true });
+  return dir;
+};
+
+const buildTargetPath = (dir: string, name: string) => `${dir}${name}.jpg`;
+
+const resizeIfNeeded = async (asset: ImagePicker.ImagePickerAsset) => {
+  const width = asset.width ?? null;
+  const height = asset.height ?? null;
+  if (!width || !height) {
+    return ImageManipulator.manipulateAsync(
+      asset.uri,
+      [],
+      { compress: JPEG_QUALITY, format: ImageManipulator.SaveFormat.JPEG },
+    );
+  }
+
+  const maxEdge = Math.max(width, height);
+  if (maxEdge <= MAX_EDGE) {
+    return ImageManipulator.manipulateAsync(
+      asset.uri,
+      [],
+      { compress: JPEG_QUALITY, format: ImageManipulator.SaveFormat.JPEG },
+    );
+  }
+
+  const scale = MAX_EDGE / maxEdge;
+  const resize = {
+    width: Math.round(width * scale),
+    height: Math.round(height * scale),
+  };
+  return ImageManipulator.manipulateAsync(
+    asset.uri,
+    [{ resize }],
+    { compress: JPEG_QUALITY, format: ImageManipulator.SaveFormat.JPEG },
+  );
+};
+
+const persistAsset = async (reportId: string, asset: ImagePicker.ImagePickerAsset) => {
+  const dir = await ensureReportPhotoDir(reportId);
+  const result = await resizeIfNeeded(asset);
+  const targetPath = buildTargetPath(dir, `${Date.now()}_${Math.random().toString(36).slice(2, 8)}`);
+  await FileSystem.moveAsync({ from: result.uri, to: targetPath });
+  return {
+    uri: targetPath,
+    width: result.width ?? asset.width ?? null,
+    height: result.height ?? asset.height ?? null,
+  };
+};
+
+const addAssetsToReport = async (
+  reportId: string,
+  assets: ImagePicker.ImagePickerAsset[],
+  isPro: boolean,
+): Promise<AddPhotoResult> => {
+  if (assets.length === 0) {
+    return { photos: [], blocked: false, canceled: false };
+  }
+
+  const existing = await listPhotosByReport(reportId);
+  const { allowedCount, blocked } = resolvePhotoAddLimit(isPro, existing.length, assets.length);
+
+  const toAdd = assets.slice(0, allowedCount);
+  const added: Photo[] = [];
+  for (let i = 0; i < toAdd.length; i += 1) {
+    const asset = toAdd[i];
+    const stored = await persistAsset(reportId, asset);
+    const photo = await createPhoto({
+      reportId,
+      localUri: stored.uri,
+      width: stored.width,
+      height: stored.height,
+      orderIndex: existing.length + i,
+    });
+    added.push(photo);
+  }
+
+  return {
+    photos: added,
+    blocked,
+    canceled: false,
+  };
+};
+
+export async function addPhotosFromCamera(
+  reportId: string,
+  isPro: boolean,
+): Promise<AddPhotoResult> {
+  const permission = await ImagePicker.requestCameraPermissionsAsync();
+  if (!permission.granted) {
+    return { photos: [], blocked: false, canceled: false, reason: 'permission' };
+  }
+
+  const result = await ImagePicker.launchCameraAsync({
+    mediaTypes: ImagePicker.MediaTypeOptions.Images,
+    allowsEditing: false,
+    quality: 1,
+  });
+
+  if (result.canceled) {
+    return { photos: [], blocked: false, canceled: true };
+  }
+
+  return addAssetsToReport(reportId, result.assets ?? [], isPro);
+}
+
+export async function addPhotosFromLibrary(
+  reportId: string,
+  isPro: boolean,
+): Promise<AddPhotoResult> {
+  const permission = await ImagePicker.requestMediaLibraryPermissionsAsync();
+  if (!permission.granted) {
+    return { photos: [], blocked: false, canceled: false, reason: 'permission' };
+  }
+
+  const result = await ImagePicker.launchImageLibraryAsync({
+    mediaTypes: ImagePicker.MediaTypeOptions.Images,
+    allowsMultipleSelection: true,
+    selectionLimit: 0,
+    quality: 1,
+  });
+
+  if (result.canceled) {
+    return { photos: [], blocked: false, canceled: true };
+  }
+
+  return addAssetsToReport(reportId, result.assets ?? [], isPro);
+}


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
写真の取り込み（カメラ/アルバム）とアプリ内保存を実装。
Free/Proの写真上限とサムネ表示を追加。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [x] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [x] test（テスト追加/修正）
- [ ] docs（ドキュメント）
- [ ] chore（雑務：依存更新など）
- [ ] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #2
- ADR: （なし）
- 参照（1つ以上推奨）:
  - constraints: docs/reference/constraints.md
  - basic_spec: docs/reference/basic_spec.md
  - functional_spec: docs/reference/functional_spec.md
  - workflow: docs/how-to/whole_workflow.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: 撮影/アルバム追加で写真をレポートへ素早く追加できる
- バグの再現条件（バグなら）: N/A

---

## 3. 変更点（What / REQUIRED）
- 写真追加（カメラ/ライブラリ）＋アプリ内コピー保存
- Free/Proの写真上限ロジック
- 写真サムネ表示（編集画面）
- 写真上限ユーティリティのテスト追加

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] カメラ/アルバムから写真を追加できる
- [x] 写真はアプリ領域にコピー保存される
- [x] Freeは1レポート10枚まで、超過時は警告
- [x] 写真は順序を保持する

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面（UI）: S-03
- 機能: F-02
- 影響する層:
  - [x] Free
  - [x] Pro
  - [ ] 両方

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし
  - [ ] あり（内容：　　　　　　　　　）
- 移行（migration）が必要:
  - [x] なし
  - [ ] あり（手順/ロールバック：　　　　　　　　　）

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [ ] なし
  - [x] あり（対象言語：18言語、英語フォールバック）
- 端末/OS差分の懸念:
  - [ ] なし
  - [x] あり（内容：写真権限）

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト（該当を残す / RECOMMENDED）
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [ ] pnpm test:e2e（結果：❌ / 理由：未実施）
- [ ] pnpm type-check（結果：❌ / 理由：未実施）
- CI（GitHub Actions）:
  - [ ] 全部 ✅
  - [ ] 一部 ❌（理由：未実行）

### 6-2. 手動確認（手順を箇条書き / REQUIRED）
1. Report Editor を開く
2. Camera で1枚追加
3. Library で複数追加
4. Freeで11枚目追加時に警告が出る
- 期待結果: 制限通りに追加できる
- 実際結果: （手動確認時に記入）

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [ ] 仕様/前提/制約が変わる → docs/reference/constraints.md を更新（リンク：）
- [ ] 用語が増える/意味が変わる → docs/reference/glossary.md を更新（リンク：）
- [ ] 運用手順が変わる → docs/how-to/whole_workflow.md を更新（リンク：）
- [ ] リリース手順に影響 → docs/how-to/android_ビルド手順.md / docs/how-to/ios_ビルド手順.md を更新（リンク：）
- [ ] 意思決定が増えた/変わった → docs/adr/ADR-XXXX.md
- [x] テスト観点が変わる → テスト（Jest）追加（__tests__/photoUtils.test.ts）
- [ ] どれも不要（理由：）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク（短く）
- 想定リスク: 端末権限拒否で追加できない
- 検知方法（どうやって気づく？）: 手動確認・ユーザー報告
- 影響の大きさ:
  - [ ] 低（困るが致命傷ではない）
  - [x] 中（ユーザーの一部が詰まる）
  - [ ] 高（課金/データ消失/起動不可など）

### 9-2. ロールバック（戻し方 / REQUIRED）
- 戻し方（最短手順）:
  - このPRをrevert
- 影響範囲の切り分け（できれば）:
  - 写真追加機能のみ

---

## 12. PRサイズ（RECOMMENDED）
- 変更行数の感覚:
  - [ ] 小（〜200行）
  - [x] 中（〜500行）
  - [ ] 大（500行超）→ 分割を検討（理由：　　　　　　　　　）

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲（UI/機能/データ/Free/Pro）を書いた
- [x] “合否が判定できる” 動作確認を記載した（自動/手動）
- [ ] CIが通った（または通せない理由を明記）
- [x] docs影響を判定し、必要なら更新した（links記載）
- [x] リスクとロールバックを書いた
