### PR TITLE
feat: home timeline list search pin delete

### DIFF
--- a/__tests__/reportListUtils.test.ts
+++ b/__tests__/reportListUtils.test.ts
@@ -1,0 +1,46 @@
+import type { Report } from '@/src/types/models';
+import { buildTimelineSections, matchesQuery } from '@/src/features/reports/reportListUtils';
+
+const makeReport = (id: string, createdAt: string, overrides: Partial<Report> = {}): Report => ({
+  id,
+  createdAt,
+  updatedAt: createdAt,
+  reportName: `Report ${id}`,
+  weather: 'none',
+  locationEnabledAtCreation: false,
+  lat: null,
+  lng: null,
+  latLngCapturedAt: null,
+  address: null,
+  addressSource: null,
+  addressLocale: null,
+  comment: '',
+  tags: [],
+  pinned: false,
+  ...overrides,
+});
+
+describe('reportListUtils', () => {
+  test('matchesQuery checks report name and comment', () => {
+    const report = makeReport('1', '2026-01-31T00:00:00.000Z', {
+      reportName: 'Main Bridge',
+      comment: 'Inspection completed',
+    });
+    expect(matchesQuery(report, 'bridge')).toBe(true);
+    expect(matchesQuery(report, 'completed')).toBe(true);
+    expect(matchesQuery(report, 'missing')).toBe(false);
+  });
+
+  test('buildTimelineSections groups pinned and date sections', () => {
+    const reports = [
+      makeReport('1', '2026-01-31T10:00:00.000Z', { pinned: true }),
+      makeReport('2', '2026-01-31T08:00:00.000Z'),
+      makeReport('3', '2026-01-30T08:00:00.000Z'),
+    ];
+    const sections = buildTimelineSections(reports, '', 'Pinned');
+    expect(sections[0].title).toBe('Pinned');
+    expect(sections[0].data).toHaveLength(1);
+    expect(sections[1].title).toBe('2026-01-31');
+    expect(sections[2].title).toBe('2026-01-30');
+  });
+});

--- a/src/core/i18n/locales/de.ts
+++ b/src/core/i18n/locales/de.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/en.ts
+++ b/src/core/i18n/locales/en.ts
@@ -247,6 +247,17 @@ const baseEn = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export type TranslationKey = keyof typeof baseEn;

--- a/src/core/i18n/locales/es.ts
+++ b/src/core/i18n/locales/es.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/fr.ts
+++ b/src/core/i18n/locales/fr.ts
@@ -251,6 +251,17 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/hi.ts
+++ b/src/core/i18n/locales/hi.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/id.ts
+++ b/src/core/i18n/locales/id.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/it.ts
+++ b/src/core/i18n/locales/it.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/ja.ts
+++ b/src/core/i18n/locales/ja.ts
@@ -220,6 +220,17 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/ko.ts
+++ b/src/core/i18n/locales/ko.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/nl.ts
+++ b/src/core/i18n/locales/nl.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/pt.ts
+++ b/src/core/i18n/locales/pt.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/ru.ts
+++ b/src/core/i18n/locales/ru.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/sv.ts
+++ b/src/core/i18n/locales/sv.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/th.ts
+++ b/src/core/i18n/locales/th.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/tr.ts
+++ b/src/core/i18n/locales/tr.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/vi.ts
+++ b/src/core/i18n/locales/vi.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/zhHans.ts
+++ b/src/core/i18n/locales/zhHans.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/core/i18n/locales/zhHant.ts
+++ b/src/core/i18n/locales/zhHant.ts
@@ -207,6 +207,18 @@ const dict = {
   photoPermissionDenied: 'Photo permission denied',
   photoAddFailed: 'Failed to add photo',
   photoEmpty: 'No photos yet.',
+  homeTitle: 'Home',
+  homeSearchPlaceholder: 'Search reports...',
+  homePinnedSection: 'Pinned',
+  homeEmptyTitle: 'No reports yet',
+  homeEmptyBody: 'Create your first report.',
+  homeCreateReport: 'Create report',
+  deleteConfirmTitle: 'Delete report?',
+  deleteConfirmBody: 'This action cannot be undone.',
+  deleteAction: 'Delete',
+  cancelAction: 'Cancel',
+  reportUnnamed: 'Untitled report',
+  reportPhotosLabel: 'photos',
 };
 
 export default dict;

--- a/src/db/reportRepository.ts
+++ b/src/db/reportRepository.ts
@@ -82,6 +82,23 @@ export async function listReports(): Promise<Report[]> {
   return rows.map(toReport);
 }
 
+export async function searchReports(query: string): Promise<Report[]> {
+  const db = await getDb();
+  const text = `%${query.trim()}%`;
+  if (!query.trim()) {
+    return listReports();
+  }
+  const rows = await db.getAllAsync<ReportRow>(
+    `SELECT ${REPORT_COLUMNS.join(', ')} FROM reports
+     WHERE report_name LIKE ? COLLATE NOCASE
+        OR comment LIKE ? COLLATE NOCASE
+     ORDER BY pinned DESC, updated_at DESC`,
+    text,
+    text,
+  );
+  return rows.map(toReport);
+}
+
 export async function getReportById(id: string): Promise<Report | null> {
   const db = await getDb();
   const row = await db.getFirstAsync<ReportRow>(

--- a/src/features/reports/reportListUtils.ts
+++ b/src/features/reports/reportListUtils.ts
@@ -1,0 +1,59 @@
+import type { Report } from '@/src/types/models';
+
+export type ReportSection = {
+  title: string;
+  data: Report[];
+};
+
+const normalizeSearchText = (value: string) => value.trim().toLowerCase();
+
+export const matchesQuery = (report: Report, query: string) => {
+  const text = normalizeSearchText(query);
+  if (!text) return true;
+  const name = report.reportName ?? '';
+  const comment = report.comment ?? '';
+  return (
+    name.toLowerCase().includes(text) ||
+    comment.toLowerCase().includes(text)
+  );
+};
+
+const formatDateKey = (iso: string) => {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso.slice(0, 10);
+  const year = date.getFullYear();
+  const month = String(date.getMonth() + 1).padStart(2, '0');
+  const day = String(date.getDate()).padStart(2, '0');
+  return `${year}-${month}-${day}`;
+};
+
+export const buildTimelineSections = (
+  reports: Report[],
+  query: string,
+  pinnedTitle: string,
+): ReportSection[] => {
+  const filtered = reports.filter((report) => matchesQuery(report, query));
+  const pinned = filtered.filter((report) => report.pinned);
+  const others = filtered.filter((report) => !report.pinned);
+
+  const sections: ReportSection[] = [];
+  if (pinned.length > 0) {
+    sections.push({ title: pinnedTitle, data: pinned });
+  }
+
+  const byDate = new Map<string, Report[]>();
+  others.forEach((report) => {
+    const key = formatDateKey(report.createdAt);
+    const current = byDate.get(key) ?? [];
+    current.push(report);
+    byDate.set(key, current);
+  });
+
+  const sortedKeys = Array.from(byDate.keys()).sort((a, b) => (a < b ? 1 : -1));
+  sortedKeys.forEach((key) => {
+    const data = byDate.get(key) ?? [];
+    sections.push({ title: key, data });
+  });
+
+  return sections;
+};

--- a/src/services/photoService.ts
+++ b/src/services/photoService.ts
@@ -30,6 +30,12 @@ const ensureReportPhotoDir = async (reportId: string) => {
   return dir;
 };
 
+const getReportPhotoDir = (reportId: string) => {
+  const documentDirectory = getDocumentDirectory();
+  if (!documentDirectory) return null;
+  return `${documentDirectory}${PHOTO_DIR_ROOT}/${reportId}/photos/`;
+};
+
 const buildTargetPath = (dir: string, name: string) => `${dir}${name}.jpg`;
 
 const resizeIfNeeded = async (asset: ImagePicker.ImagePickerAsset) => {
@@ -153,4 +159,17 @@ export async function addPhotosFromLibrary(
   }
 
   return addAssetsToReport(reportId, result.assets ?? [], isPro);
+}
+
+export async function removeReportPhotos(reportId: string, cached?: Photo[]) {
+  const photos = cached ?? (await listPhotosByReport(reportId));
+  await Promise.all(
+    photos.map((photo) =>
+      FileSystem.deleteAsync(photo.localUri, { idempotent: true }),
+    ),
+  );
+  const dir = getReportPhotoDir(reportId);
+  if (dir) {
+    await FileSystem.deleteAsync(dir, { idempotent: true });
+  }
 }


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
Homeにタイムライン表示（検索/ピン/削除）を追加。
日付区切りとサムネ表示でレポートを見返しやすくした。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [x] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [x] test（テスト追加/修正）
- [ ] docs（ドキュメント）
- [ ] chore（雑務：依存更新など）
- [ ] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #4
- ADR: （なし）
- 参照（1つ以上推奨）:
  - basic_spec: docs/reference/basic_spec.md
  - functional_spec: docs/reference/functional_spec.md
  - workflow: docs/how-to/whole_workflow.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: 過去レポートをすぐ探して見返せるようにする
- バグの再現条件（バグなら）: N/A

---

## 3. 変更点（What / REQUIRED）
- Homeタイムライン（SectionList）
- 検索（レポート名/コメント部分一致）
- ピン留め/解除
- 削除（確認ダイアログ）
- 先頭写真サムネ＋写真枚数表示
- フィルタ/グルーピングロジックのテスト

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] Homeにレポートが時系列表示される
- [x] 検索でレポートが絞り込める
- [x] ピン留めは上部に固定される
- [x] 削除は確認ダイアログ後に実行される

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面（UI）: S-01
- 機能: F-03/F-04
- 影響する層:
  - [x] Free
  - [x] Pro
  - [ ] 両方

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし
  - [ ] あり（内容：　　　　　　　　　）
- 移行（migration）が必要:
  - [x] なし
  - [ ] あり（手順/ロールバック：　　　　　　　　　）

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [ ] なし
  - [x] あり（対象言語：18言語、英語フォールバック）
- 端末/OS差分の懸念:
  - [ ] なし
  - [x] あり（内容：大量データ時の性能）

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト（該当を残す / RECOMMENDED）
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [ ] pnpm test:e2e（結果：❌ / 理由：未実施）
- [ ] pnpm type-check（結果：❌ / 理由：未実施）
- CI（GitHub Actions）:
  - [ ] 全部 ✅
  - [ ] 一部 ❌（理由：未実行）

### 6-2. 手動確認（手順を箇条書き / REQUIRED）
1. Homeを開く
2. 検索入力でレポートが絞り込まれる
3. ピン留めで上部固定される
4. 削除で確認ダイアログが出て削除される
- 期待結果: 仕様通り動作
- 実際結果: （手動確認時に記入）

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [ ] 仕様/前提/制約が変わる → docs/reference/constraints.md を更新（リンク：）
- [ ] 用語が増える/意味が変わる → docs/reference/glossary.md を更新（リンク：）
- [ ] 運用手順が変わる → docs/how-to/whole_workflow.md を更新（リンク：）
- [ ] リリース手順に影響 → docs/how-to/android_ビルド手順.md / docs/how-to/ios_ビルド手順.md を更新（リンク：）
- [ ] 意思決定が増えた/変わった → docs/adr/ADR-XXXX.md
- [x] テスト観点が変わる → テスト追加（__tests__/reportListUtils.test.ts）
- [ ] どれも不要（理由：）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク（短く）
- 想定リスク: レポート数が多いと描画が重くなる
- 検知方法（どうやって気づく？）: 手動計測/ユーザー報告
- 影響の大きさ:
  - [ ] 低（困るが致命傷ではない）
  - [x] 中（ユーザーの一部が詰まる）
  - [ ] 高（課金/データ消失/起動不可など）

### 9-2. ロールバック（戻し方 / REQUIRED）
- 戻し方（最短手順）:
  - このPRをrevert
- 影響範囲の切り分け（できれば）:
  - Home画面のみ

---

## 12. PRサイズ（RECOMMENDED）
- 変更行数の感覚:
  - [ ] 小（〜200行）
  - [x] 中（〜500行）
  - [ ] 大（500行超）→ 分割を検討（理由：　　　　　　　　　）

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲（UI/機能/データ/Free/Pro）を書いた
- [x] “合否が判定できる” 動作確認を記載した（自動/手動）
- [ ] CIが通った（または通せない理由を明記）
- [x] docs影響を判定し、必要なら更新した（links記載）
- [x] リスクとロールバックを書いた
