### PR TITLE
feat: paywall + pro state store (issue #6)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -16,6 +16,7 @@ export default function RootLayout() {
     <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+        <Stack.Screen name="pro" options={{ headerShown: false }} />
         <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
       </Stack>
       <StatusBar style="auto" />

--- a/app/pro.tsx
+++ b/app/pro.tsx
@@ -1,0 +1,5 @@
+import PaywallScreen from '@/src/features/pro/PaywallScreen';
+
+export default function ProScreen() {
+  return <PaywallScreen />;
+}

--- a/src/features/pro/PaywallScreen.tsx
+++ b/src/features/pro/PaywallScreen.tsx
@@ -1,0 +1,361 @@
+import { useEffect, useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { useTranslation } from '@/src/core/i18n/i18n';
+import { proService, type PlanType, type PriceDetails } from '@/src/services/proService';
+import { useProStore } from '@/src/stores/proStore';
+
+const DEFAULT_BADGE = '#ffb800';
+
+export default function PaywallScreen() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const isPro = useProStore((s) => s.isPro);
+  const initPro = useProStore((s) => s.init);
+  const refreshPro = useProStore((s) => s.refresh);
+  const purchasePro = useProStore((s) => s.purchase);
+  const restorePro = useProStore((s) => s.restore);
+
+  const [priceDetails, setPriceDetails] = useState<PriceDetails | null>(null);
+  const [loadingPrices, setLoadingPrices] = useState(true);
+  const [action, setAction] = useState<PlanType | 'restore' | null>(null);
+
+  useEffect(() => {
+    void initPro();
+    refreshPro().catch(() => null);
+  }, [initPro, refreshPro]);
+
+  useEffect(() => {
+    let mounted = true;
+    setLoadingPrices(true);
+    proService
+      .getPriceDetails()
+      .then((details) => {
+        if (mounted) setPriceDetails(details);
+      })
+      .catch(() => {
+        if (mounted) setPriceDetails(null);
+      })
+      .finally(() => {
+        if (mounted) setLoadingPrices(false);
+      });
+
+    return () => {
+      mounted = false;
+    };
+  }, []);
+
+  const monthlyPriceLabel = useMemo(() => {
+    if (loadingPrices) return t.priceLoading;
+    return priceDetails?.monthly?.priceString ?? t.priceUnavailable;
+  }, [loadingPrices, priceDetails?.monthly?.priceString, t.priceLoading, t.priceUnavailable]);
+
+  const yearlyPriceLabel = useMemo(() => {
+    if (loadingPrices) return t.priceLoading;
+    return priceDetails?.yearly?.priceString ?? t.priceUnavailable;
+  }, [loadingPrices, priceDetails?.yearly?.priceString, t.priceLoading, t.priceUnavailable]);
+
+  const yearlyPerMonth = priceDetails?.yearly?.pricePerMonthString ?? null;
+  const monthlyAvailable = Boolean(priceDetails?.monthly?.priceString);
+  const yearlyAvailable = Boolean(priceDetails?.yearly?.priceString);
+
+  const handlePurchase = async (plan: PlanType) => {
+    if (isPro) return;
+    setAction(plan);
+    try {
+      await purchasePro(plan);
+      Alert.alert(t.purchaseSuccess);
+      router.back();
+    } catch {
+      Alert.alert(t.purchaseFailed);
+    } finally {
+      setAction(null);
+    }
+  };
+
+  const handleRestore = async () => {
+    setAction('restore');
+    try {
+      const result = await restorePro();
+      Alert.alert(result.hasActive ? t.restoreSuccess : t.restoreNotFound);
+      if (result.hasActive) router.back();
+    } catch {
+      Alert.alert(t.restoreFailed);
+    } finally {
+      setAction(null);
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.headerRow}>
+        <Pressable onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backText}>{'‹'}</Text>
+        </Pressable>
+        <Text style={styles.headerTitle}>{t.proHeaderTitle}</Text>
+      </View>
+
+      <View style={styles.hero}>
+        <Text style={styles.heroTitle}>{t.proHeaderTitle}</Text>
+        <Text style={styles.heroSubtitle}>{t.proCompareSubtitle}</Text>
+        {isPro && (
+          <View style={styles.activeBadge}>
+            <Text style={styles.activeBadgeText}>{t.proBadgeShort}</Text>
+            <Text style={styles.activeBadgeSub}>{t.purchaseSuccess}</Text>
+          </View>
+        )}
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>{t.proCompareTitle}</Text>
+        <View style={styles.planCard}>
+          <View style={styles.planRow}>
+            <Text style={styles.planTitle}>{t.proPlanMonthlyTitle}</Text>
+            <Text style={styles.planPrice}>{monthlyPriceLabel}</Text>
+          </View>
+          <Pressable
+            onPress={() => handlePurchase('monthly')}
+            style={[
+              styles.ctaButton,
+              (!monthlyAvailable || isPro) && styles.disabledButton,
+            ]}
+            disabled={!monthlyAvailable || isPro || action !== null}>
+            {action === 'monthly' ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.ctaText}>{t.proCtaMonthly}</Text>
+            )}
+          </Pressable>
+        </View>
+
+        <View style={[styles.planCard, styles.planHighlight]}>
+          <View style={styles.planRow}>
+            <Text style={styles.planTitle}>{t.proPlanYearlyTitle}</Text>
+            <View style={styles.badge}>
+              <Text style={styles.badgeText}>{t.proPlanYearlyBadge}</Text>
+            </View>
+          </View>
+          <Text style={styles.planPrice}>{yearlyPriceLabel}</Text>
+          {yearlyPerMonth && (
+            <Text style={styles.planSub}>{`${t.subscriptionDetailsPerMonthLabel}: ${yearlyPerMonth}`}</Text>
+          )}
+          <Text style={styles.planSub}>{t.proYearlySavingShort}</Text>
+          <Pressable
+            onPress={() => handlePurchase('yearly')}
+            style={[
+              styles.ctaButton,
+              (!yearlyAvailable || isPro) && styles.disabledButton,
+            ]}
+            disabled={!yearlyAvailable || isPro || action !== null}>
+            {action === 'yearly' ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.ctaText}>{t.proCtaYearly}</Text>
+            )}
+          </Pressable>
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>{t.restore}</Text>
+        <Text style={styles.sectionSub}>{t.restoreDesc}</Text>
+        <Pressable
+          onPress={handleRestore}
+          style={[styles.secondaryButton, action === 'restore' && styles.disabledButton]}
+          disabled={action !== null}>
+          {action === 'restore' ? (
+            <ActivityIndicator />
+          ) : (
+            <Text style={styles.secondaryText}>{t.restore}</Text>
+          )}
+        </Pressable>
+      </View>
+
+      <Text style={styles.finePrint}>{t.proFinePrint}</Text>
+
+      <Pressable onPress={() => router.back()} style={styles.stayFreeButton}>
+        <Text style={styles.stayFreeText}>{t.proCtaStayFree}</Text>
+      </Pressable>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    paddingBottom: 40,
+    gap: 16,
+    backgroundColor: '#f6f6f6',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  backButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#ddd',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  backText: {
+    fontSize: 20,
+    color: '#333',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#222',
+  },
+  hero: {
+    padding: 16,
+    borderRadius: 16,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#eee',
+    gap: 8,
+  },
+  heroTitle: {
+    fontSize: 22,
+    fontWeight: '700',
+    color: '#111',
+  },
+  heroSubtitle: {
+    fontSize: 13,
+    color: '#666',
+    lineHeight: 18,
+  },
+  activeBadge: {
+    marginTop: 8,
+    padding: 10,
+    borderRadius: 12,
+    backgroundColor: '#e7f6ea',
+    borderWidth: 1,
+    borderColor: '#b9e4c5',
+    gap: 4,
+  },
+  activeBadgeText: {
+    fontSize: 12,
+    fontWeight: '700',
+    color: '#1f7a3e',
+  },
+  activeBadgeSub: {
+    fontSize: 12,
+    color: '#1f7a3e',
+  },
+  section: {
+    padding: 16,
+    borderRadius: 16,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#eee',
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#111',
+  },
+  sectionSub: {
+    fontSize: 12,
+    color: '#666',
+  },
+  planCard: {
+    padding: 14,
+    borderRadius: 14,
+    borderWidth: 1,
+    borderColor: '#e0e0e0',
+    backgroundColor: '#fafafa',
+    gap: 8,
+  },
+  planHighlight: {
+    borderColor: DEFAULT_BADGE,
+    backgroundColor: '#fff7e0',
+  },
+  planRow: {
+    flexDirection: 'row',
+    justifyContent: 'space-between',
+    alignItems: 'center',
+  },
+  planTitle: {
+    fontSize: 16,
+    fontWeight: '600',
+    color: '#222',
+  },
+  planPrice: {
+    fontSize: 18,
+    fontWeight: '700',
+    color: '#111',
+  },
+  planSub: {
+    fontSize: 12,
+    color: '#666',
+  },
+  badge: {
+    paddingHorizontal: 8,
+    paddingVertical: 3,
+    borderRadius: 999,
+    backgroundColor: DEFAULT_BADGE,
+  },
+  badgeText: {
+    fontSize: 11,
+    fontWeight: '700',
+    color: '#4b2d00',
+  },
+  ctaButton: {
+    marginTop: 6,
+    paddingVertical: 10,
+    borderRadius: 12,
+    backgroundColor: '#111',
+    alignItems: 'center',
+  },
+  ctaText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    paddingVertical: 10,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#ddd',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+  },
+  secondaryText: {
+    color: '#111',
+    fontWeight: '600',
+  },
+  finePrint: {
+    fontSize: 11,
+    color: '#777',
+    lineHeight: 16,
+  },
+  stayFreeButton: {
+    paddingVertical: 12,
+    borderRadius: 12,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#ddd',
+    alignItems: 'center',
+  },
+  stayFreeText: {
+    fontWeight: '600',
+    color: '#333',
+  },
+  disabledButton: {
+    opacity: 0.5,
+  },
+});

--- a/src/stores/proStore.ts
+++ b/src/stores/proStore.ts
@@ -1,0 +1,61 @@
+import { create } from 'zustand';
+
+import type { ProState } from '@/src/types/models';
+import { proService, type PlanType } from '@/src/services/proService';
+
+type ProStore = {
+  state: ProState | null;
+  isPro: boolean;
+  initialized: boolean;
+  busy: boolean;
+  init: () => Promise<void>;
+  refresh: () => Promise<void>;
+  purchase: (plan: PlanType) => Promise<ProState>;
+  restore: () => Promise<{ state: ProState; hasActive: boolean }>;
+};
+
+export const useProStore = create<ProStore>((set, get) => ({
+  state: null,
+  isPro: false,
+  initialized: false,
+  busy: false,
+  init: async () => {
+    if (get().initialized) return;
+    const local = await proService.loadLocalState();
+    if (local) {
+      set({ state: local, isPro: local.isPro });
+    }
+    set({ initialized: true });
+  },
+  refresh: async () => {
+    set({ busy: true });
+    try {
+      const state = await proService.refreshCustomerInfo();
+      if (state) {
+        set({ state, isPro: state.isPro, initialized: true });
+      }
+    } finally {
+      set({ busy: false });
+    }
+  },
+  purchase: async (plan) => {
+    set({ busy: true });
+    try {
+      const state = await proService.purchase(plan);
+      set({ state, isPro: state.isPro, initialized: true });
+      return state;
+    } finally {
+      set({ busy: false });
+    }
+  },
+  restore: async () => {
+    set({ busy: true });
+    try {
+      const result = await proService.restore();
+      set({ state: result.state, isPro: result.state.isPro, initialized: true });
+      return result;
+    } finally {
+      set({ busy: false });
+    }
+  },
+}));


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
Paywall（S-06）を追加し、RevenueCatの価格表示・購入・復元とPro状態のStore連携を実装しました。
無料制限でのアップグレード導線（写真追加・PDF出力）をPaywallに接続しています。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [x] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [ ] test（テスト追加/修正）
- [ ] docs（ドキュメント）
- [ ] chore（雑務：依存更新など）
- [ ] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #6
- ADR: 該当なし
- 参照（1つ以上推奨）:
  - constraints: docs/reference/constraints.md
  - functional_spec: docs/reference/functional_spec.md
  - workflow: docs/how-to/whole_workflow.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: Free/Pro差分を成立させ、アップグレード導線と購入/復元を提供する。
- バグの再現条件（バグなら）: 該当なし。

---

## 3. 変更点（What / REQUIRED）
- Paywall画面（S-06）を追加し、月/年価格表示・購入・復元を実装
- Pro状態のStore（SecureStore保存のproService連携）を追加
- PDF出力制限/写真追加制限のアップグレード導線をPaywallへ接続
- 新規ルート `/pro` を追加（Stackでheader非表示）

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] Paywallで月/年の価格が表示される（取得不可時はUnavailable）
- [x] 購入完了でPro状態がONになる（Store反映）
- [x] Restore purchasesで復元できる
- [x] Pro状態はSecureStoreに保存される（proService）

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面（UI）: S-05（PDFプレビュー）, S-06（Paywall）
- 機能: F-06（課金/復元）
- 影響する層:
  - [ ] Free
  - [ ] Pro
  - [x] 両方

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし
  - [ ] あり（内容：）
- 移行（migration）が必要:
  - [x] なし
  - [ ] あり（手順/ロールバック：）

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [x] なし
  - [ ] あり（対象言語：）
- 端末/OS差分の懸念:
  - [ ] なし
  - [x] あり（内容：RevenueCat設定がない場合は価格取得不可の表示）

---

## 6. 動作確認（How to test / REQUIRED）

### 6-1. 自動テスト（該当を残す / RECOMMENDED）
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [ ] pnpm test:e2e（結果：❌）※未導入
- [ ] pnpm type-check（結果：❌）※scriptsなし
- CI（GitHub Actions）:
  - [ ] 全部 ✅
  - [ ] 一部 ❌（理由：ローカルのみ）

### 6-2. 手動確認（手順を箇条書き / REQUIRED）
1. PDFプレビュー画面で「Large」→「Upgrade」を押してPaywallが開く
2. Paywallで月/年の価格が表示される（RC設定があれば実価格）
3. 「Restore Purchases」を押し、復元成功/未購入のアラートが出る
4. Freeで写真10枚制限に到達→アップグレード導線が出る
- 期待結果: Paywall/復元/Pro状態が反映される
- 実際結果: 未検証（端末で確認予定）

### 6-3. 再現手順（バグ修正なら / RECOMMENDED）
- Before（修正前の再現）: 該当なし
- After（修正後に再現しない）: 該当なし

---

## 7. UI差分（UI変更がある場合 / REQUIRED if UI）
- Before: なし
- After : Paywall画面新規追加
- Figma: 該当なし

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [ ] 仕様/前提/制約が変わる → docs/reference/constraints.md を更新（リンク：）
- [ ] 用語が増える/意味が変わる → docs/reference/glossary.md を更新（リンク：）
- [ ] 運用手順が変わる → docs/how-to/whole_workflow.md を更新（リンク：）
- [ ] リリース手順に影響 → docs/how-to/android_ビルド手順.md / docs/how-to/ios_ビルド手順.md を更新（リンク：）
- [ ] 意思決定が増えた/変わった → docs/adr/ADR-XXXX.md を追加 or 更新（リンク：）
- [ ] テスト観点が変わる → テスト（Jest/Maestro）を追加/更新（リンク or 該当ファイル：）
- [x] どれも不要（理由：既存仕様内の実装追加）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク（短く）
- 想定リスク: RevenueCat設定不足で購入/復元が動作しない
- 検知方法（どうやって気づく？）: 手動テスト/ストア審査
- 影響の大きさ:
  - [ ] 低（困るが致命傷ではない）
  - [x] 中（ユーザーの一部が詰まる）
  - [ ] 高（課金/データ消失/起動不可など）

### 9-2. ロールバック（戻し方 / REQUIRED）
- 戻し方（最短手順）:
  - このPRをrevertしてPaywallルートと導線を削除
- 影響範囲の切り分け（できれば）:
  - 課金導線（PDF/写真制限）のみ

---

## 10. セキュリティ / 課金 / 広告（該当時のみ / REQUIRED if 該当）
- [x] Secrets/キーを直書きしていない（APIキー/広告ユニットID/RevenueCat等）
- [x] 個人情報をログ出力していない
- [x] 通信はHTTPS前提で問題ない
- [x] 課金（RevenueCat）の影響がある → 購入/復元/解約導線の確認手順を「6」に追記した
- [ ] 広告（AdMob）の影響がある → Freeのみ表示 / Proはゼロ を確認する手順を「6」に追記した
- [ ] 外部GitHub Actionsの追加/更新がある → 第三者Actionは commit SHA pin した

---

## 11. リリース影響（release/hotfix だけ / RECOMMENDED）
- ストア提出が必要:
  - [ ] なし
  - [x] あり（iOS / Android）
- 段階配信を推奨:
  - [ ] なし
  - [ ] あり（理由：）
- 監視ポイント（24〜48h）:
  - クラッシュ:
  - レビュー:
  - 課金:
  - 広告:

---

## 12. PRサイズ（RECOMMENDED）
- 変更行数の感覚:
  - [ ] 小（〜200行）
  - [x] 中（〜500行）
  - [ ] 大（500行超）→ 分割を検討（理由：）

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲（UI/機能/データ/Free/Pro）を書いた
- [x] “合否が判定できる” 動作確認を記載した（自動/手動）
- [ ] CIが通った（または通せない理由を明記）
- [x] docs影響を判定し、必要なら更新した（links記載）
- [x] リスクとロールバックを書いた
