### PR TITLE
feat: backup export/import zip (issue #8)

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -62,8 +62,18 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     },
   );
 
-  const pluginsWithAdMob = ensurePlugin(
+  const pluginsWithBuildProps = ensurePlugin(
     pluginsWithLocalization,
+    'expo-build-properties',
+    {
+      ios: {
+        deploymentTarget: '15.5',
+      },
+    },
+  );
+
+  const pluginsWithAdMob = ensurePlugin(
+    pluginsWithBuildProps,
     'react-native-google-mobile-ads',
     {
       androidAppId: admobAndroidAppId,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -17,6 +17,7 @@ export default function RootLayout() {
       <Stack>
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="pro" options={{ headerShown: false }} />
+        <Stack.Screen name="backup" options={{ headerShown: false }} />
         <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
       </Stack>
       <StatusBar style="auto" />

--- a/app/backup.tsx
+++ b/app/backup.tsx
@@ -1,0 +1,5 @@
+import BackupScreen from '@/src/features/backup/BackupScreen';
+
+export default function BackupRoute() {
+  return <BackupScreen />;
+}

--- a/docs/adr/ADR-0004-backup-zip.md
+++ b/docs/adr/ADR-0004-backup-zip.md
@@ -1,0 +1,93 @@
+---
+
+# ADR-0004: バックアップはZIP形式で出力し、react-native-zip-archiveを採用する
+
+- Status: Accepted
+- Date: 2026-01-31
+- Deciders: @doooooraku / Codex
+- Related: Issue #8 / PR #21 / constraints
+
+---
+
+## Context（背景：いま何に困っている？）
+- 現状：バックアップの形式は `manifest.json + photos/` が決定済み。
+- 困りごと：iOS/Androidの保存先選択を統一し、ファイルとして扱える形式が必要。
+- 制約/前提（リンク推奨）：
+  - `docs/reference/constraints.md`（外部SDK追加時はADR）
+  - `docs/reference/functional_spec.md`（F-07 バックアップ）
+
+---
+
+## Decision（決めたこと：結論）
+- 決定：バックアップはZIP形式で保存し、`react-native-zip-archive` でzip/unzipを行う。
+- 適用範囲：S-08 バックアップ（Export/Import）
+
+---
+
+## Decision Drivers（判断の軸：何を大事にした？）
+- OS共通で「1ファイル」として扱えること
+- 端末内ストレージに依存しない保存/共有導線
+- 実装と保守の安定性
+
+---
+
+## Alternatives considered（他の案と却下理由）
+
+### Option A: フォルダ保存（ZIPなし）
+- 概要：manifest + photos をフォルダで保存
+- 良い点：追加ライブラリ不要
+- 悪い点：iOSで保存先選択が難しい（共有シートはファイル前提）
+- 却下理由：OS間の体験差が大きい
+
+### Option B: JSのみでZIP生成
+- 概要：純JSのZIPライブラリを利用
+- 良い点：ネイティブ依存が減る
+- 悪い点：大量写真でメモリ負荷が高い
+- 却下理由：安定性と性能が不安
+
+---
+
+## Consequences（結果：嬉しいこと/辛いこと/副作用）
+
+### Positive（嬉しい）
+- 1ファイルで保存/共有ができる
+- Import/ExportがOS共通の手順になる
+
+### Negative（辛い/副作用）
+- iOSのデプロイターゲット制約（ライブラリ要件）
+- 追加SDKの保守コストが増える
+
+### Follow-ups（後でやる宿題）
+- [ ] バックアップの手順をHow-toへ整理（必要なら）
+
+---
+
+## Acceptance / Tests（合否：テストに寄せる）
+- 正（自動テスト）：
+  - Jest：対象なし（ファイルI/O/SDK）
+- 手動チェック：
+  - Exportでzipが保存できる
+  - Importで復元できる
+
+---
+
+## Rollout / Rollback（出し方/戻し方）
+- リリース手順への影響：Dev Client / ネイティブビルドが必要
+- ロールバック方針：バックアップ機能を一時非表示にして次リリースへ
+- 検知方法：手動テスト/ストア審査
+
+---
+
+## Links（関連リンク：正へ寄せる）
+- constraints: `docs/reference/constraints.md`
+- Issue: #8
+- PR: #21
+- External docs:
+  - https://github.com/mockingbot/react-native-zip-archive
+  - https://docs.expo.dev/versions/latest/sdk/sharing/
+  - https://docs.expo.dev/versions/latest/sdk/document-picker/
+
+---
+
+## Notes（メモ：任意）
+- iOS 15.5 以上が必要なため、ビルド設定と整合させる。

--- a/docs/reference/constraints.md
+++ b/docs/reference/constraints.md
@@ -141,6 +141,7 @@
 - Expo SQLite: https://docs.expo.dev/versions/latest/sdk/sqlite/
 - RevenueCat Restore Purchases: https://www.revenuecat.com/docs/getting-started/restoring-purchases
 - react-native-google-mobile-ads（テストID等）: https://docs.page/invertase/react-native-google-mobile-ads/displaying-ads
+- react-native-zip-archive（バックアップzip）: https://github.com/mockingbot/react-native-zip-archive
 - GitHub Branch protection: https://docs.github.com/en/repositories/configuring-branches-and-merges-in-your-repository/managing-protected-branches/managing-a-branch-protection-rule
 - IANA Language Subtag Registry: https://www.iana.org/assignments/language-subtag-registry
 - RFC 5646 (BCP47): https://datatracker.ietf.org/doc/html/rfc5646

--- a/package.json
+++ b/package.json
@@ -30,6 +30,7 @@
     "dotenv": "^17.2.3",
     "expo": "~54.0.27",
     "expo-asset": "~12.0.12",
+    "expo-build-properties": "^1.0.10",
     "expo-constants": "~18.0.11",
     "expo-dev-client": "~6.0.20",
     "expo-document-picker": "~14.0.8",
@@ -67,6 +68,7 @@
     "react-native-screens": "~4.16.0",
     "react-native-web": "~0.21.0",
     "react-native-worklets": "0.5.1",
+    "react-native-zip-archive": "^7.0.2",
     "tamagui": "1.138.5",
     "zustand": "^5.0.8"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -50,6 +50,9 @@ importers:
       expo-asset:
         specifier: ~12.0.12
         version: 12.0.12(expo@54.0.32)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      expo-build-properties:
+        specifier: ^1.0.10
+        version: 1.0.10(expo@54.0.32)
       expo-constants:
         specifier: ~18.0.11
         version: 18.0.13(expo@54.0.32)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
@@ -161,6 +164,9 @@ importers:
       react-native-worklets:
         specifier: 0.5.1
         version: 0.5.1(@babel/core@7.28.5)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      react-native-zip-archive:
+        specifier: ^7.0.2
+        version: 7.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       tamagui:
         specifier: 1.138.5
         version: 1.138.5(react-dom@19.1.0(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -3479,6 +3485,11 @@ packages:
       react: '*'
       react-native: '*'
 
+  expo-build-properties@1.0.10:
+    resolution: {integrity: sha512-mFCZbrbrv0AP5RB151tAoRzwRJelqM7bCJzCkxpu+owOyH+p/rFC/q7H5q8B9EpVWj8etaIuszR+gKwohpmu1Q==}
+    peerDependencies:
+      expo: '*'
+
   expo-constants@18.0.13:
     resolution: {integrity: sha512-FnZn12E1dRYKDHlAdIyNFhBurKTS3F9CrfrBDJI5m3D7U17KBHMQ6JEfYlSj7LG7t+Ulr+IKaj58L1k5gBwTcQ==}
     peerDependencies:
@@ -5273,6 +5284,12 @@ packages:
       '@babel/core': ^7.0.0-0
       react: '*'
       react-native: '*'
+
+  react-native-zip-archive@7.0.2:
+    resolution: {integrity: sha512-msCRJMcwH6NVZ2/zoC+1nvA0wlpYRnMxteQywS9nt4BzXn48tZpaVtE519QEZn0xe3ygvgsWx5cdPoE9Jx3bsg==}
+    peerDependencies:
+      react: '>=16.8.6'
+      react-native: '>=0.60.0'
 
   react-native@0.81.5:
     resolution: {integrity: sha512-1w+/oSjEXZjMqsIvmkCRsOc8UBYv163bTWKTI8+1mxztvQPhCRYGTvZ/PL1w16xXHneIj/SLGfxWg2GWN2uexw==}
@@ -10475,7 +10492,7 @@ snapshots:
       eslint: 9.39.1
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1))(eslint@9.39.1)
       eslint-plugin-expo: 1.0.0(eslint@9.39.1)(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1))(eslint@9.39.1))(eslint@9.39.1)
       eslint-plugin-react: 7.37.5(eslint@9.39.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.1)
       globals: 16.5.0
@@ -10512,7 +10529,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1))(eslint@9.39.1))(eslint@9.39.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10549,7 +10566,7 @@ snapshots:
       lodash: 4.17.21
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1))(eslint@9.39.1))(eslint@9.39.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9
@@ -10751,6 +10768,12 @@ snapshots:
       react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
     transitivePeerDependencies:
       - supports-color
+
+  expo-build-properties@1.0.10(expo@54.0.32):
+    dependencies:
+      ajv: 8.17.1
+      expo: 54.0.32(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      semver: 7.7.3
 
   expo-constants@18.0.13(expo@54.0.32)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)):
     dependencies:
@@ -12950,6 +12973,11 @@ snapshots:
       semver: 7.7.2
     transitivePeerDependencies:
       - supports-color
+
+  react-native-zip-archive@7.0.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0):
+    dependencies:
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
 
   react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0):
     dependencies:

--- a/src/core/i18n/locales/en.ts
+++ b/src/core/i18n/locales/en.ts
@@ -76,6 +76,30 @@ const baseEn = {
   openPro: 'View Pro Plan',
   cancel: 'Cancel',
 
+  // --- Backup ---
+  backupTitle: 'Backup',
+  backupExportTitle: 'Export backup',
+  backupExportDesc: 'Creates a zip with manifest.json and photos/. PDFs are not included.',
+  backupExportAction: 'Export',
+  backupExportSuccess: 'Backup exported.',
+  backupExportFailed: 'Failed to export backup.',
+  backupShareUnavailableTitle: 'Sharing unavailable',
+  backupShareUnavailableBody: 'This device cannot open the share sheet.',
+  backupImportTitle: 'Import backup',
+  backupImportDesc: 'Import a backup zip. This replaces current reports and photos.',
+  backupImportAction: 'Import',
+  backupImportSuccess: 'Backup imported.',
+  backupImportSuccessDetail: 'Imported {reports} reports and {photos} photos.',
+  backupImportFailed: 'Failed to import backup.',
+  backupImportWarningTitle: 'Replace current data?',
+  backupImportWarningBody: 'Import replaces existing reports and photos. This cannot be undone.',
+  backupInvalidTitle: 'Invalid backup',
+  backupInvalidBody: 'The file does not contain a valid manifest.',
+  backupSchemaMismatchTitle: 'Unsupported backup',
+  backupSchemaMismatchBody: 'This backup uses a different schema version.',
+  backupUnsupportedTitle: 'Not supported',
+  backupUnsupportedBody: 'Backup is not supported on this device.',
+
   // --- Settings (Appearance) ---
   flowEffectTitle: 'Electric flow animation',
   flowEffectHelp:

--- a/src/db/photoRepository.ts
+++ b/src/db/photoRepository.ts
@@ -46,6 +46,14 @@ export async function listPhotosByReport(reportId: string): Promise<Photo[]> {
   return rows.map(toPhoto);
 }
 
+export async function listAllPhotos(): Promise<Photo[]> {
+  const db = await getDb();
+  const rows = await db.getAllAsync<PhotoRow>(
+    `SELECT ${PHOTO_COLUMNS.join(', ')} FROM photos ORDER BY report_id ASC, order_index ASC`,
+  );
+  return rows.map(toPhoto);
+}
+
 export async function getFirstPhotosByReportIds(
   reportIds: string[],
 ): Promise<Record<string, Photo>> {

--- a/src/features/backup/BackupScreen.tsx
+++ b/src/features/backup/BackupScreen.tsx
@@ -1,0 +1,199 @@
+import { useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Text,
+  View,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { useTranslation } from '@/src/core/i18n/i18n';
+import { BackupError, exportBackup, importBackup } from '@/src/features/backup/backupService';
+
+export default function BackupScreen() {
+  const router = useRouter();
+  const { t } = useTranslation();
+  const [exporting, setExporting] = useState(false);
+  const [importing, setImporting] = useState(false);
+
+  const handleExport = async () => {
+    if (exporting || importing) return;
+    setExporting(true);
+    try {
+      await exportBackup();
+      Alert.alert(t.backupExportSuccess);
+    } catch (error) {
+      if (error instanceof BackupError && error.code === 'unsupported') {
+        Alert.alert(t.backupUnsupportedTitle, t.backupUnsupportedBody);
+      } else if (error instanceof BackupError && error.code === 'share') {
+        Alert.alert(t.backupShareUnavailableTitle, t.backupShareUnavailableBody);
+      } else {
+        Alert.alert(t.backupExportFailed);
+      }
+    } finally {
+      setExporting(false);
+    }
+  };
+
+  const executeImport = async () => {
+    setImporting(true);
+    try {
+      const result = await importBackup();
+      if (!result) return;
+      Alert.alert(
+        t.backupImportSuccess,
+        t.backupImportSuccessDetail
+          .replace('{reports}', String(result.reports))
+          .replace('{photos}', String(result.photos)),
+      );
+    } catch (error) {
+      if (error instanceof BackupError && error.code === 'schema') {
+        Alert.alert(t.backupSchemaMismatchTitle, t.backupSchemaMismatchBody);
+      } else if (error instanceof BackupError && error.code === 'invalid') {
+        Alert.alert(t.backupInvalidTitle, t.backupInvalidBody);
+      } else if (error instanceof BackupError && error.code === 'unsupported') {
+        Alert.alert(t.backupUnsupportedTitle, t.backupUnsupportedBody);
+      } else {
+        Alert.alert(t.backupImportFailed);
+      }
+    } finally {
+      setImporting(false);
+    }
+  };
+
+  const handleImport = () => {
+    if (exporting || importing) return;
+    Alert.alert(t.backupImportWarningTitle, t.backupImportWarningBody, [
+      { text: t.cancel, style: 'cancel' },
+      {
+        text: t.backupImportAction,
+        style: 'destructive',
+        onPress: () => {
+          void executeImport();
+        },
+      },
+    ]);
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.headerRow}>
+        <Pressable onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backText}>{'‹'}</Text>
+        </Pressable>
+        <Text style={styles.headerTitle}>{t.backupTitle}</Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>{t.backupExportTitle}</Text>
+        <Text style={styles.sectionBody}>{t.backupExportDesc}</Text>
+        <Pressable
+          onPress={handleExport}
+          style={[styles.primaryButton, exporting && styles.disabledButton]}
+          disabled={exporting || importing}>
+          {exporting ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.primaryButtonText}>{t.backupExportAction}</Text>
+          )}
+        </Pressable>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>{t.backupImportTitle}</Text>
+        <Text style={styles.sectionBody}>{t.backupImportDesc}</Text>
+        <Pressable
+          onPress={handleImport}
+          style={[styles.secondaryButton, importing && styles.disabledButton]}
+          disabled={exporting || importing}>
+          {importing ? (
+            <ActivityIndicator />
+          ) : (
+            <Text style={styles.secondaryButtonText}>{t.backupImportAction}</Text>
+          )}
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    paddingBottom: 40,
+    gap: 16,
+    backgroundColor: '#f6f6f6',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  backButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#ddd',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  backText: {
+    fontSize: 20,
+    color: '#333',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#222',
+  },
+  section: {
+    padding: 16,
+    borderRadius: 16,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#eee',
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#111',
+  },
+  sectionBody: {
+    fontSize: 13,
+    color: '#666',
+    lineHeight: 18,
+  },
+  primaryButton: {
+    marginTop: 4,
+    paddingVertical: 12,
+    borderRadius: 12,
+    backgroundColor: '#111',
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    marginTop: 4,
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#ddd',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+  },
+  secondaryButtonText: {
+    color: '#111',
+    fontWeight: '600',
+  },
+  disabledButton: {
+    opacity: 0.6,
+  },
+});

--- a/src/features/backup/backupService.ts
+++ b/src/features/backup/backupService.ts
@@ -1,0 +1,354 @@
+import { Platform } from 'react-native';
+import Constants from 'expo-constants';
+import * as DocumentPicker from 'expo-document-picker';
+import * as FileSystem from 'expo-file-system';
+import * as Sharing from 'expo-sharing';
+import { unzip, zip } from 'react-native-zip-archive';
+
+import { getDb } from '@/src/db/db';
+import { listReports } from '@/src/db/reportRepository';
+import { listAllPhotos } from '@/src/db/photoRepository';
+import { useSettingsStore } from '@/src/stores/settingsStore';
+import { getLang, setLang } from '@/src/core/i18n/i18n';
+import {
+  clampComment,
+  normalizeAddressSource,
+  normalizeTags,
+  normalizeWeather,
+  roundCoordinate,
+} from '@/src/features/reports/reportUtils';
+import type { AddressSource, WeatherType } from '@/src/types/models';
+
+const BACKUP_SCHEMA_VERSION = 1;
+const BACKUP_MANIFEST = 'manifest.json';
+const BACKUP_PHOTOS_DIR = 'photos';
+const PHOTO_ROOT = 'repolog/reports';
+
+export type BackupManifest = {
+  schemaVersion: number;
+  exportedAt: string;
+  appVersion?: string | null;
+  reports: BackupReport[];
+  photos: BackupPhoto[];
+  settings: BackupSettings;
+  tagHistory?: string[];
+  reportNameHistory?: string[];
+};
+
+export type BackupReport = {
+  id: string;
+  createdAt: string;
+  updatedAt: string;
+  reportName: string | null;
+  weather: WeatherType;
+  locationEnabledAtCreation: boolean;
+  lat: number | null;
+  lng: number | null;
+  latLngCapturedAt: string | null;
+  address: string | null;
+  addressSource: AddressSource | null;
+  addressLocale: string | null;
+  comment: string;
+  tags: string[];
+  pinned: boolean;
+};
+
+export type BackupPhoto = {
+  id: string;
+  reportId: string;
+  fileName: string;
+  width: number | null;
+  height: number | null;
+  createdAt: string;
+  orderIndex: number;
+};
+
+export type BackupSettings = {
+  includeLocation: boolean;
+  language: string;
+};
+
+export type BackupImportResult = {
+  reports: number;
+  photos: number;
+};
+
+type BackupErrorCode = 'unsupported' | 'invalid' | 'schema' | 'share';
+
+export class BackupError extends Error {
+  code: BackupErrorCode;
+
+  constructor(code: BackupErrorCode, message?: string) {
+    super(message ?? code);
+    this.code = code;
+  }
+}
+
+const getDocumentDirectory = () =>
+  FileSystem.Paths?.document?.uri ?? (FileSystem as unknown as { documentDirectory?: string }).documentDirectory;
+
+const getCacheDirectory = () =>
+  FileSystem.Paths?.cache?.uri ?? (FileSystem as unknown as { cacheDirectory?: string }).cacheDirectory;
+
+const stripFileScheme = (uri: string) => uri.replace(/^file:\/\//, '');
+
+const ensureDir = async (uri: string) => {
+  await FileSystem.makeDirectoryAsync(uri, { intermediates: true });
+};
+
+const getReportPhotoDir = (reportId: string) => {
+  const documentDirectory = getDocumentDirectory();
+  if (!documentDirectory) return null;
+  return `${documentDirectory}${PHOTO_ROOT}/${reportId}/photos/`;
+};
+
+const getBackupRoot = () => {
+  const cacheDirectory = getCacheDirectory();
+  if (!cacheDirectory) return null;
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  return `${cacheDirectory}repolog-backup-${stamp}/`;
+};
+
+const buildManifest = (reports: BackupReport[], photos: BackupPhoto[]): BackupManifest => {
+  const includeLocation = useSettingsStore.getState().includeLocation;
+  return {
+    schemaVersion: BACKUP_SCHEMA_VERSION,
+    exportedAt: new Date().toISOString(),
+    appVersion: Constants.expoConfig?.version ?? null,
+    reports,
+    photos,
+    settings: {
+      includeLocation,
+      language: getLang(),
+    },
+    tagHistory: [],
+    reportNameHistory: [],
+  };
+};
+
+const findManifestRoot = async (baseDir: string) => {
+  const directPath = `${baseDir}${BACKUP_MANIFEST}`;
+  const directInfo = await FileSystem.getInfoAsync(directPath);
+  if (directInfo.exists) return baseDir;
+
+  const entries = await FileSystem.readDirectoryAsync(baseDir);
+  for (const entry of entries) {
+    const candidate = `${baseDir}${entry}/`;
+    const candidateInfo = await FileSystem.getInfoAsync(`${candidate}${BACKUP_MANIFEST}`);
+    if (candidateInfo.exists) {
+      return candidate;
+    }
+  }
+
+  return null;
+};
+
+export async function exportBackup(): Promise<void> {
+  if (Platform.OS === 'web') {
+    throw new BackupError('unsupported');
+  }
+  const sharingAvailable = await Sharing.isAvailableAsync();
+  if (!sharingAvailable) {
+    throw new BackupError('share');
+  }
+
+  const backupRoot = getBackupRoot();
+  if (!backupRoot) {
+    throw new BackupError('unsupported');
+  }
+  const photosDir = `${backupRoot}${BACKUP_PHOTOS_DIR}/`;
+  await ensureDir(photosDir);
+
+  const reports = await listReports();
+  const photos = await listAllPhotos();
+
+  const backupReports: BackupReport[] = reports.map((report) => ({
+    id: report.id,
+    createdAt: report.createdAt,
+    updatedAt: report.updatedAt,
+    reportName: report.reportName ?? null,
+    weather: report.weather,
+    locationEnabledAtCreation: report.locationEnabledAtCreation,
+    lat: report.lat,
+    lng: report.lng,
+    latLngCapturedAt: report.latLngCapturedAt ?? null,
+    address: report.address ?? null,
+    addressSource: report.addressSource ?? null,
+    addressLocale: report.addressLocale ?? null,
+    comment: report.comment ?? '',
+    tags: report.tags ?? [],
+    pinned: report.pinned,
+  }));
+
+  const backupPhotos: BackupPhoto[] = [];
+  for (const photo of photos) {
+    const fileName = `${photo.id}.jpg`;
+    const targetPath = `${photosDir}${fileName}`;
+    const info = await FileSystem.getInfoAsync(photo.localUri);
+    if (!info.exists) {
+      throw new BackupError('invalid', 'Missing photo file');
+    }
+    await FileSystem.copyAsync({ from: photo.localUri, to: targetPath });
+    backupPhotos.push({
+      id: photo.id,
+      reportId: photo.reportId,
+      fileName,
+      width: photo.width ?? null,
+      height: photo.height ?? null,
+      createdAt: photo.createdAt,
+      orderIndex: photo.orderIndex,
+    });
+  }
+
+  const manifest = buildManifest(backupReports, backupPhotos);
+  await FileSystem.writeAsStringAsync(
+    `${backupRoot}${BACKUP_MANIFEST}`,
+    JSON.stringify(manifest, null, 2),
+  );
+
+  const zipPath = `${backupRoot.replace(/\/$/, '')}.zip`;
+  await zip(stripFileScheme(backupRoot), stripFileScheme(zipPath));
+
+  try {
+    await Sharing.shareAsync(zipPath, {
+      mimeType: 'application/zip',
+      UTI: 'public.zip-archive',
+    });
+  } finally {
+    await FileSystem.deleteAsync(backupRoot, { idempotent: true });
+    await FileSystem.deleteAsync(zipPath, { idempotent: true });
+  }
+}
+
+export async function importBackup(): Promise<BackupImportResult | null> {
+  if (Platform.OS === 'web') {
+    throw new BackupError('unsupported');
+  }
+
+  const result = await DocumentPicker.getDocumentAsync({
+    type: 'application/zip',
+    copyToCacheDirectory: true,
+  });
+
+  if (result.canceled) {
+    return null;
+  }
+
+  const asset = result.assets?.[0];
+  if (!asset?.uri) {
+    throw new BackupError('invalid');
+  }
+
+  const cacheDirectory = getCacheDirectory();
+  if (!cacheDirectory) {
+    throw new BackupError('unsupported');
+  }
+
+  const importRoot = `${cacheDirectory}repolog-import-${Date.now()}/`;
+  await ensureDir(importRoot);
+
+  await unzip(stripFileScheme(asset.uri), stripFileScheme(importRoot));
+
+  const manifestRoot = await findManifestRoot(importRoot);
+  if (!manifestRoot) {
+    throw new BackupError('invalid');
+  }
+
+  const manifestPath = `${manifestRoot}${BACKUP_MANIFEST}`;
+  const raw = await FileSystem.readAsStringAsync(manifestPath);
+  const manifest = JSON.parse(raw) as BackupManifest;
+
+  if (manifest.schemaVersion !== BACKUP_SCHEMA_VERSION) {
+    throw new BackupError('schema');
+  }
+
+  const photosDir = `${manifestRoot}${BACKUP_PHOTOS_DIR}/`;
+  const photosDirInfo = await FileSystem.getInfoAsync(photosDir);
+  if (!photosDirInfo.exists) {
+    throw new BackupError('invalid');
+  }
+
+  for (const photo of manifest.photos ?? []) {
+    const sourcePath = `${photosDir}${photo.fileName}`;
+    const sourceInfo = await FileSystem.getInfoAsync(sourcePath);
+    if (!sourceInfo.exists) {
+      throw new BackupError('invalid');
+    }
+  }
+
+  const documentDirectory = getDocumentDirectory();
+  if (!documentDirectory) {
+    throw new BackupError('unsupported');
+  }
+
+  const reportRoot = `${documentDirectory}${PHOTO_ROOT}/`;
+  await FileSystem.deleteAsync(reportRoot, { idempotent: true });
+
+  const db = await getDb();
+  await db.withTransactionAsync(async () => {
+    await db.runAsync('DELETE FROM reports');
+
+    for (const report of manifest.reports ?? []) {
+      const weather = normalizeWeather(report.weather ?? 'none');
+      const addressSource = normalizeAddressSource(report.addressSource ?? null);
+      const tags = normalizeTags(report.tags ?? []);
+      await db.runAsync(
+        `INSERT INTO reports (
+          id, created_at, updated_at, report_name, weather, location_enabled,
+          lat, lng, lat_lng_captured_at, address, address_source, address_locale,
+          comment, tags_json, pinned
+        ) VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)`,
+        report.id,
+        report.createdAt,
+        report.updatedAt,
+        report.reportName ?? null,
+        weather,
+        report.locationEnabledAtCreation ? 1 : 0,
+        roundCoordinate(report.lat ?? null),
+        roundCoordinate(report.lng ?? null),
+        report.latLngCapturedAt ?? null,
+        report.address ?? null,
+        addressSource,
+        report.addressLocale ?? null,
+        clampComment(report.comment ?? ''),
+        JSON.stringify(tags),
+        report.pinned ? 1 : 0,
+      );
+    }
+
+    for (const photo of manifest.photos ?? []) {
+      const targetDir = getReportPhotoDir(photo.reportId);
+      if (!targetDir) {
+        throw new BackupError('unsupported');
+      }
+      await ensureDir(targetDir);
+      const targetPath = `${targetDir}${photo.fileName}`;
+      const sourcePath = `${photosDir}${photo.fileName}`;
+      await FileSystem.copyAsync({ from: sourcePath, to: targetPath });
+      await db.runAsync(
+        `INSERT INTO photos (
+          id, report_id, local_uri, width, height, created_at, order_index
+        ) VALUES (?, ?, ?, ?, ?, ?, ?)`,
+        photo.id,
+        photo.reportId,
+        targetPath,
+        photo.width ?? null,
+        photo.height ?? null,
+        photo.createdAt,
+        photo.orderIndex,
+      );
+    }
+  });
+
+  if (manifest.settings?.includeLocation !== undefined) {
+    useSettingsStore.getState().setIncludeLocation(Boolean(manifest.settings.includeLocation));
+  }
+  if (manifest.settings?.language) {
+    setLang(manifest.settings.language as any);
+  }
+
+  return {
+    reports: manifest.reports?.length ?? 0,
+    photos: manifest.photos?.length ?? 0,
+  };
+}


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
バックアップ（Export/Import）をZIP形式で実装し、manifest.json + photos/ を出力/復元できるようにしました。
Dev Client前提でzip/unzipを行い、設定（言語/位置ON/OFF）も復元します。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [x] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [ ] test（テスト追加/修正）
- [ ] docs（ドキュメント）
- [ ] chore（雑務：依存更新など）
- [ ] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #8
- ADR: docs/adr/ADR-0004-backup-zip.md
- 参照（1つ以上推奨）:
  - constraints: docs/reference/constraints.md
  - functional_spec: docs/reference/functional_spec.md
  - workflow: docs/how-to/whole_workflow.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: 端末変更/紛失時に自己完結で復元できるようにする。
- バグの再現条件（バグなら）: 該当なし。

---

## 3. 変更点（What / REQUIRED）
- バックアップExport/ImportのZIPフローを追加
- `manifest.json + photos/` を生成/復元
- 設定（言語/位置ON-OFF）を復元
- zip/unzip用SDKとADR追加

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] Exportでzipとして保存できる
- [x] Importで同じ状態を復元できる
- [x] schemaVersionが違う場合はエラー表示

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面（UI）: S-08 Backup
- 機能: F-07 Backup
- 影響する層:
  - [ ] Free
  - [ ] Pro
  - [x] 両方

### 5-2. データ/互換性
- 既存データへの影響:
  - [ ] なし
  - [x] あり（内容：Import時は既存レポートを置換）
- 移行（migration）が必要:
  - [x] なし
  - [ ] あり（手順/ロールバック：）

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [x] なし
  - [ ] あり（対象言語：）
- 端末/OS差分の懸念:
  - [ ] なし
  - [x] あり（内容：Dev Clientが必要、Expo Go不可）

---

## 6. 動作確認（How to test / REQUIRED）

### 6-1. 自動テスト（該当を残す / RECOMMENDED）
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [ ] pnpm test:e2e（結果：❌）※未導入
- [x] pnpm type-check（結果：✅）
- CI（GitHub Actions）:
  - [ ] 全部 ✅
  - [ ] 一部 ❌（理由：ローカルのみ）

### 6-2. 手動確認（手順を箇条書き / REQUIRED）
1. /backup を開く（Dev Client）
2. Exportを押してzipが保存される
3. Importを押して同じzipを選択
4. レポート/写真/設定が復元される
- 期待結果: 復元後に同じ状態を確認できる
- 実際結果: 未検証（端末で確認予定）

### 6-3. 再現手順（バグ修正なら / RECOMMENDED）
- Before（修正前の再現）: 該当なし
- After（修正後に再現しない）: 該当なし

---

## 7. UI差分（UI変更がある場合 / REQUIRED if UI）
- Before: なし
- After : Backup画面追加
- Figma: 該当なし

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [ ] 仕様/前提/制約が変わる → docs/reference/constraints.md を更新（リンク：）
- [ ] 用語が増える/意味が変わる → docs/reference/glossary.md を更新（リンク：）
- [ ] 運用手順が変わる → docs/how-to/whole_workflow.md を更新（リンク：）
- [ ] リリース手順に影響 → docs/how-to/android_ビルド手順.md / docs/how-to/ios_ビルド手順.md を更新（リンク：）
- [x] 意思決定が増えた/変わった → docs/adr/ADR-0004-backup-zip.md を追加
- [ ] テスト観点が変わる → テスト（Jest/Maestro）を追加/更新（リンク or 該当ファイル：）
- [ ] どれも不要（理由：）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク（短く）
- 想定リスク: 不正なzipやschema mismatchで復元できない
- 検知方法（どうやって気づく？）: 手動テスト/エラー表示
- 影響の大きさ:
  - [ ] 低（困るが致命傷ではない）
  - [x] 中（ユーザーの一部が詰まる）
  - [ ] 高（課金/データ消失/起動不可など）

### 9-2. ロールバック（戻し方 / REQUIRED）
- 戻し方（最短手順）:
  - このPRをrevertしてBackup画面/機能を削除
- 影響範囲の切り分け（できれば）:
  - Backup機能のみ

---

## 10. セキュリティ / 課金 / 広告（該当時のみ / REQUIRED if 該当）
- [x] Secrets/キーを直書きしていない（APIキー/広告ユニットID/RevenueCat等）
- [x] 個人情報をログ出力していない
- [x] 通信はHTTPS前提で問題ない
- [ ] 課金（RevenueCat）の影響がある → 購入/復元/解約導線の確認手順を「6」に追記した
- [ ] 広告（AdMob）の影響がある → Freeのみ表示 / Proはゼロ を確認する手順を「6」に追記した
- [ ] 外部GitHub Actionsの追加/更新がある → 第三者Actionは commit SHA pin した

---

## 11. リリース影響（release/hotfix だけ / RECOMMENDED）
- ストア提出が必要:
  - [ ] なし
  - [x] あり（iOS / Android）
- 段階配信を推奨:
  - [ ] なし
  - [ ] あり（理由：）
- 監視ポイント（24〜48h）:
  - クラッシュ:
  - レビュー:
  - 課金:
  - 広告:

---

## 12. PRサイズ（RECOMMENDED）
- 変更行数の感覚:
  - [ ] 小（〜200行）
  - [ ] 中（〜500行）
  - [x] 大（500行超）→ 分割を検討（理由：初回実装で不可分）

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲（UI/機能/データ/Free/Pro）を書いた
- [x] “合否が判定できる” 動作確認を記載した（自動/手動）
- [ ] CIが通った（または通せない理由を明記）
- [x] docs影響を判定し、必要なら更新した（links記載）
- [x] リスクとロールバックを書いた
