### PR TITLE
feat: settings screen (issue #9)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -13,6 +13,7 @@ import { useRouter } from 'expo-router';
 import { Image } from 'expo-image';
 
 import { AdBanner } from '@/components/ad-banner';
+import { IconSymbol } from '@/components/ui/icon-symbol';
 import { useTranslation } from '@/src/core/i18n/i18n';
 import { deleteReport, listReports, searchReports, updateReport } from '@/src/db/reportRepository';
 import {
@@ -137,7 +138,14 @@ export default function HomeScreen() {
 
   return (
     <View style={styles.container}>
-      <Text style={styles.title}>{t.homeTitle}</Text>
+      <View style={styles.headerRow}>
+        <Text style={styles.title}>{t.homeTitle}</Text>
+        <Pressable
+          onPress={() => router.push('/settings')}
+          style={styles.iconButton}>
+          <IconSymbol name="gearshape.fill" size={20} color="#111" />
+        </Pressable>
+      </View>
       <TextInput
         placeholder={t.homeSearchPlaceholder}
         value={query}
@@ -183,10 +191,26 @@ const styles = StyleSheet.create({
     alignItems: 'center',
     justifyContent: 'center',
   },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
   title: {
     fontSize: 20,
     fontWeight: '700',
     color: '#111',
+  },
+  iconButton: {
+    width: 36,
+    height: 36,
+    borderRadius: 18,
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#eee',
   },
   search: {
     marginTop: 12,

--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -18,6 +18,7 @@ export default function RootLayout() {
         <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
         <Stack.Screen name="pro" options={{ headerShown: false }} />
         <Stack.Screen name="backup" options={{ headerShown: false }} />
+        <Stack.Screen name="settings" options={{ headerShown: false }} />
         <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
       </Stack>
       <StatusBar style="auto" />

--- a/app/settings.tsx
+++ b/app/settings.tsx
@@ -1,0 +1,5 @@
+import SettingsScreen from '@/src/features/settings/SettingsScreen';
+
+export default function SettingsRoute() {
+  return <SettingsScreen />;
+}

--- a/components/ui/icon-symbol.tsx
+++ b/components/ui/icon-symbol.tsx
@@ -18,6 +18,7 @@ const MAPPING = {
   'paperplane.fill': 'send',
   'chevron.left.forwardslash.chevron.right': 'code',
   'chevron.right': 'chevron-right',
+  'gearshape.fill': 'settings',
 } as IconMapping;
 
 /**

--- a/src/core/i18n/locales/en.ts
+++ b/src/core/i18n/locales/en.ts
@@ -13,6 +13,12 @@ const baseEn = {
   sound: 'Sound',
   haptics: 'Haptics',
   theme: 'Theme',
+  settingsSectionGeneral: 'General',
+  settingsSectionPrivacy: 'Privacy',
+  settingsSectionPurchases: 'Purchases',
+  settingsSectionBackup: 'Backup',
+  settingsBackupDesc: 'Export or import a backup zip (manifest.json + photos/).',
+  settingsBackupOpen: 'Open Backup',
 
   // --- Purchase / Restore ---
   restore: 'Restore Purchases',

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -1,0 +1,261 @@
+import { useMemo, useState } from 'react';
+import {
+  ActivityIndicator,
+  Alert,
+  Pressable,
+  ScrollView,
+  StyleSheet,
+  Switch,
+  Text,
+  View,
+} from 'react-native';
+import { useRouter } from 'expo-router';
+
+import { useTranslation, type Lang, type TranslationKey } from '@/src/core/i18n/i18n';
+import { useSettingsStore } from '@/src/stores/settingsStore';
+import { useProStore } from '@/src/stores/proStore';
+
+const LANGUAGE_OPTIONS: { code: Lang; labelKey: TranslationKey }[] = [
+  { code: 'en', labelKey: 'languageNameEn' },
+  { code: 'ja', labelKey: 'languageNameJa' },
+  { code: 'fr', labelKey: 'languageNameFr' },
+  { code: 'es', labelKey: 'languageNameEs' },
+  { code: 'de', labelKey: 'languageNameDe' },
+  { code: 'it', labelKey: 'languageNameIt' },
+  { code: 'pt', labelKey: 'languageNamePt' },
+  { code: 'ru', labelKey: 'languageNameRu' },
+  { code: 'zhHans', labelKey: 'languageNameZhHans' },
+  { code: 'zhHant', labelKey: 'languageNameZhHant' },
+  { code: 'ko', labelKey: 'languageNameKo' },
+  { code: 'th', labelKey: 'languageNameTh' },
+  { code: 'id', labelKey: 'languageNameId' },
+  { code: 'vi', labelKey: 'languageNameVi' },
+  { code: 'hi', labelKey: 'languageNameHi' },
+  { code: 'tr', labelKey: 'languageNameTr' },
+  { code: 'nl', labelKey: 'languageNameNl' },
+  { code: 'sv', labelKey: 'languageNameSv' },
+];
+
+export default function SettingsScreen() {
+  const router = useRouter();
+  const { t, lang, setLang } = useTranslation();
+  const includeLocation = useSettingsStore((s) => s.includeLocation);
+  const setIncludeLocation = useSettingsStore((s) => s.setIncludeLocation);
+  const restorePurchases = useProStore((s) => s.restore);
+
+  const [showLanguages, setShowLanguages] = useState(false);
+  const [restoring, setRestoring] = useState(false);
+
+  const currentLanguageLabel = useMemo(() => {
+    const matched = LANGUAGE_OPTIONS.find((option) => option.code === lang);
+    if (!matched) return lang;
+    return t[matched.labelKey] ?? matched.code;
+  }, [lang, t]);
+
+  const handleRestore = async () => {
+    if (restoring) return;
+    setRestoring(true);
+    try {
+      const result = await restorePurchases();
+      Alert.alert(result.hasActive ? t.restoreSuccess : t.restoreNotFound);
+    } catch {
+      Alert.alert(t.restoreFailed);
+    } finally {
+      setRestoring(false);
+    }
+  };
+
+  return (
+    <ScrollView contentContainerStyle={styles.container}>
+      <View style={styles.headerRow}>
+        <Pressable onPress={() => router.back()} style={styles.backButton}>
+          <Text style={styles.backText}>{'‹'}</Text>
+        </Pressable>
+        <Text style={styles.headerTitle}>{t.settings}</Text>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>{t.settingsSectionGeneral}</Text>
+        <Text style={styles.sectionBody}>{t.languageChange}</Text>
+        <Pressable
+          onPress={() => setShowLanguages((prev) => !prev)}
+          style={styles.rowBetween}>
+          <Text style={styles.valueText}>{`${t.currentLanguage}: ${currentLanguageLabel}`}</Text>
+          <Text style={styles.chevron}>{showLanguages ? '▲' : '▼'}</Text>
+        </Pressable>
+        {showLanguages && (
+          <View style={styles.optionList}>
+            {LANGUAGE_OPTIONS.map((option) => {
+              const active = option.code === lang;
+              return (
+                <Pressable
+                  key={option.code}
+                  onPress={() => setLang(option.code)}
+                  style={[styles.optionRow, active && styles.optionRowActive]}>
+                  <Text style={[styles.optionText, active && styles.optionTextActive]}>
+                    {t[option.labelKey] ?? option.code}
+                  </Text>
+                  {active && <Text style={styles.optionCheck}>✓</Text>}
+                </Pressable>
+              );
+            })}
+          </View>
+        )}
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>{t.settingsSectionPrivacy}</Text>
+        <Text style={styles.sectionBody}>{t.includeLocationHelp}</Text>
+        <View style={styles.rowBetween}>
+          <Text style={styles.valueText}>{t.includeLocationLabel}</Text>
+          <Switch value={includeLocation} onValueChange={setIncludeLocation} />
+        </View>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>{t.settingsSectionPurchases}</Text>
+        <Text style={styles.sectionBody}>{t.restoreDesc}</Text>
+        <Pressable
+          onPress={handleRestore}
+          style={[styles.primaryButton, restoring && styles.disabledButton]}
+          disabled={restoring}>
+          {restoring ? (
+            <ActivityIndicator color="#fff" />
+          ) : (
+            <Text style={styles.primaryButtonText}>{t.restore}</Text>
+          )}
+        </Pressable>
+      </View>
+
+      <View style={styles.section}>
+        <Text style={styles.sectionTitle}>{t.settingsSectionBackup}</Text>
+        <Text style={styles.sectionBody}>{t.settingsBackupDesc}</Text>
+        <Pressable onPress={() => router.push('/backup')} style={styles.secondaryButton}>
+          <Text style={styles.secondaryButtonText}>{t.settingsBackupOpen}</Text>
+        </Pressable>
+      </View>
+    </ScrollView>
+  );
+}
+
+const styles = StyleSheet.create({
+  container: {
+    padding: 16,
+    paddingBottom: 40,
+    gap: 16,
+    backgroundColor: '#f6f6f6',
+  },
+  headerRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: 12,
+  },
+  backButton: {
+    width: 32,
+    height: 32,
+    borderRadius: 16,
+    borderWidth: 1,
+    borderColor: '#ddd',
+    alignItems: 'center',
+    justifyContent: 'center',
+    backgroundColor: '#fff',
+  },
+  backText: {
+    fontSize: 20,
+    color: '#333',
+  },
+  headerTitle: {
+    fontSize: 18,
+    fontWeight: '600',
+    color: '#222',
+  },
+  section: {
+    padding: 16,
+    borderRadius: 16,
+    backgroundColor: '#fff',
+    borderWidth: 1,
+    borderColor: '#eee',
+    gap: 12,
+  },
+  sectionTitle: {
+    fontSize: 14,
+    fontWeight: '600',
+    color: '#111',
+  },
+  sectionBody: {
+    fontSize: 13,
+    color: '#666',
+    lineHeight: 18,
+  },
+  rowBetween: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    gap: 12,
+  },
+  valueText: {
+    fontSize: 13,
+    color: '#222',
+  },
+  chevron: {
+    fontSize: 12,
+    color: '#666',
+  },
+  optionList: {
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#eee',
+    overflow: 'hidden',
+  },
+  optionRow: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+    paddingVertical: 10,
+    paddingHorizontal: 12,
+    borderBottomWidth: 1,
+    borderBottomColor: '#f0f0f0',
+  },
+  optionRowActive: {
+    backgroundColor: '#f5f5f5',
+  },
+  optionText: {
+    fontSize: 13,
+    color: '#333',
+  },
+  optionTextActive: {
+    fontWeight: '600',
+    color: '#111',
+  },
+  optionCheck: {
+    fontSize: 12,
+    color: '#111',
+  },
+  primaryButton: {
+    marginTop: 4,
+    paddingVertical: 12,
+    borderRadius: 12,
+    backgroundColor: '#111',
+    alignItems: 'center',
+  },
+  primaryButtonText: {
+    color: '#fff',
+    fontWeight: '600',
+  },
+  secondaryButton: {
+    marginTop: 4,
+    paddingVertical: 12,
+    borderRadius: 12,
+    borderWidth: 1,
+    borderColor: '#ddd',
+    alignItems: 'center',
+    backgroundColor: '#fff',
+  },
+  secondaryButtonText: {
+    color: '#111',
+    fontWeight: '600',
+  },
+  disabledButton: {
+    opacity: 0.6,
+  },
+});


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
Settings画面を追加し、言語切替・位置情報ON/OFF・購入復元・バックアップ遷移を提供しました。
Homeのヘッダーに設定アイコンを追加して導線を作成しています。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [x] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [ ] test（テスト追加/修正）
- [ ] docs（ドキュメント）
- [ ] chore（雑務：依存更新など）
- [ ] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #9
- ADR: 該当なし
- 参照（1つ以上推奨）:
  - constraints: docs/reference/constraints.md
  - functional_spec: docs/reference/functional_spec.md
  - workflow: docs/how-to/whole_workflow.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: 言語/位置/復元/バックアップの主要設定を1画面に集約する。
- バグの再現条件（バグなら）: 該当なし。

---

## 3. 変更点（What / REQUIRED）
- Settings画面を追加（言語切替/位置トグル/復元/バックアップ）
- Homeヘッダーに設定アイコンを追加
- ルート `/settings` を追加

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] 言語切替ができる
- [x] 位置情報ON/OFFができる
- [x] Restore purchasesを呼べる
- [x] バックアップ画面へ遷移できる

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面（UI）: S-01 Home / S-07 Settings
- 機能: 言語/位置情報/復元/バックアップ導線
- 影響する層:
  - [ ] Free
  - [ ] Pro
  - [x] 両方

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし
  - [ ] あり（内容：）
- 移行（migration）が必要:
  - [x] なし
  - [ ] あり（手順/ロールバック：）

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [ ] なし
  - [x] あり（対象言語：英語キー追加、他言語はfallback）
- 端末/OS差分の懸念:
  - [ ] なし
  - [x] あり（内容：Restoreはストア環境依存）

---

## 6. 動作確認（How to test / REQUIRED）

### 6-1. 自動テスト（該当を残す / RECOMMENDED）
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [ ] pnpm test:e2e（結果：❌）※未導入
- [ ] pnpm type-check（結果：未実施）
- CI（GitHub Actions）:
  - [ ] 全部 ✅
  - [ ] 一部 ❌（理由：ローカルのみ）

### 6-2. 手動確認（手順を箇条書き / REQUIRED）
1. Home右上の⚙からSettingsを開く
2. 言語を変更→即座にUIが切り替わる
3. 位置情報トグルをON/OFF→保存される
4. Restore purchasesボタンを押す
5. Backupボタンで /backup へ遷移できる
- 期待結果: 各設定が反映される
- 実際結果: 未検証（端末で確認予定）

### 6-3. 再現手順（バグ修正なら / RECOMMENDED）
- Before（修正前の再現）: 該当なし
- After（修正後に再現しない）: 該当なし

---

## 7. UI差分（UI変更がある場合 / REQUIRED if UI）
- Before: なし
- After : Settings画面追加 / Homeヘッダーにアイコン
- Figma: 該当なし

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [ ] 仕様/前提/制約が変わる → docs/reference/constraints.md を更新（リンク：）
- [ ] 用語が増える/意味が変わる → docs/reference/glossary.md を更新（リンク：）
- [ ] 運用手順が変わる → docs/how-to/whole_workflow.md を更新（リンク：）
- [ ] リリース手順に影響 → docs/how-to/android_ビルド手順.md / docs/how-to/ios_ビルド手順.md を更新（リンク：）
- [ ] 意思決定が増えた/変わった → docs/adr/ADR-XXXX.md を追加 or 更新（リンク：）
- [ ] テスト観点が変わる → テスト（Jest/Maestro）を追加/更新（リンク or 該当ファイル：）
- [x] どれも不要（理由：既存仕様内のUI追加）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク（短く）
- 想定リスク: 設定が保存されず混乱
- 検知方法（どうやって気づく？）: 手動テスト
- 影響の大きさ:
  - [x] 低（困るが致命傷ではない）
  - [ ] 中（ユーザーの一部が詰まる）
  - [ ] 高（課金/データ消失/起動不可など）

### 9-2. ロールバック（戻し方 / REQUIRED）
- 戻し方（最短手順）:
  - このPRをrevertしてSettings画面/導線を削除
- 影響範囲の切り分け（できれば）:
  - Settings画面のみ

---

## 10. セキュリティ / 課金 / 広告（該当時のみ / REQUIRED if 該当）
- [x] Secrets/キーを直書きしていない（APIキー/広告ユニットID/RevenueCat等）
- [x] 個人情報をログ出力していない
- [x] 通信はHTTPS前提で問題ない
- [x] 課金（RevenueCat）の影響がある → 購入/復元の確認手順を「6」に追記した
- [ ] 広告（AdMob）の影響がある → Freeのみ表示 / Proはゼロ を確認する手順を「6」に追記した
- [ ] 外部GitHub Actionsの追加/更新がある → 第三者Actionは commit SHA pin した

---

## 11. リリース影響（release/hotfix だけ / RECOMMENDED）
- ストア提出が必要:
  - [ ] なし
  - [x] あり（iOS / Android）
- 段階配信を推奨:
  - [ ] なし
  - [ ] あり（理由：）
- 監視ポイント（24〜48h）:
  - クラッシュ:
  - レビュー:
  - 課金:
  - 広告:

---

## 12. PRサイズ（RECOMMENDED）
- 変更行数の感覚:
  - [ ] 小（〜200行）
  - [x] 中（〜500行）
  - [ ] 大（500行超）→ 分割を検討（理由：）

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲（UI/機能/データ/Free/Pro）を書いた
- [x] “合否が判定できる” 動作確認を記載した（自動/手動）
- [ ] CIが通った（または通せない理由を明記）
- [x] docs影響を判定し、必要なら更新した（links記載）
- [x] リスクとロールバックを書いた
