### PR TITLE
docs: switch legal pages deployment source to gh-pages

### DIFF
--- a/docs/how-to/legal_pages_github_pages.md
+++ b/docs/how-to/legal_pages_github_pages.md
@@ -19,6 +19,7 @@ This document explains how Repolog publishes legal pages for store review.
 
 - `docs/privacy/index.html`
 - `docs/terms/index.html`
+- `docs/index.html` (root redirect)
 
 ## 4. Configure GitHub Pages once
 
@@ -28,8 +29,8 @@ Run this command:
 gh api -X POST \
   -H "Accept: application/vnd.github+json" \
   /repos/doooooraku/Repolog/pages \
-  -f source[branch]=main \
-  -f source[path]=/docs
+  -f source[branch]=gh-pages \
+  -f source[path]=/
 ```
 
 If Pages is already configured, update with:
@@ -38,11 +39,26 @@ If Pages is already configured, update with:
 gh api -X PUT \
   -H "Accept: application/vnd.github+json" \
   /repos/doooooraku/Repolog/pages \
-  -f source[branch]=main \
-  -f source[path]=/docs
+  -f source[branch]=gh-pages \
+  -f source[path]=/
 ```
 
-## 5. App config linkage
+## 5. Sync legal files to `gh-pages`
+
+`gh-pages` should contain only static legal pages so Jekyll does not parse the whole `docs/` tree.
+
+```bash
+git worktree add /tmp/repolog-gh-pages gh-pages
+mkdir -p /tmp/repolog-gh-pages/privacy /tmp/repolog-gh-pages/terms
+cp docs/index.html /tmp/repolog-gh-pages/index.html
+cp docs/privacy/index.html /tmp/repolog-gh-pages/privacy/index.html
+cp docs/terms/index.html /tmp/repolog-gh-pages/terms/index.html
+git -C /tmp/repolog-gh-pages add .
+git -C /tmp/repolog-gh-pages commit -m "docs: sync legal pages"
+git -C /tmp/repolog-gh-pages push origin gh-pages
+```
+
+## 6. App config linkage
 
 Legal URLs are read from `app.config.ts` via Expo `extra`:
 
@@ -51,7 +67,7 @@ Legal URLs are read from `app.config.ts` via Expo `extra`:
 
 Defaults point to the URLs in section 2.
 
-## 6. Optional override for staging
+## 7. Optional override for staging
 
 You can override URLs with env vars:
 
@@ -61,7 +77,7 @@ LEGAL_TERMS_URL=https://example.com/terms \
 pnpm start
 ```
 
-## 7. Review checklist
+## 8. Review checklist
 
 - `https://doooooraku.github.io/Repolog/privacy/` returns HTTP 200
 - `https://doooooraku.github.io/Repolog/terms/` returns HTTP 200


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
GitHub Pagesの公開元を `gh-pages` 専用ブランチに統一する運用へ修正し、
法務ページ手順書を実運用に合わせました。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [ ] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [ ] test（テスト追加/修正）
- [x] docs（ドキュメント）
- [x] chore（雑務：依存更新など）
- [ ] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #27
- ADR: なし
- 参照（1つ以上推奨）:
  - constraints: docs/reference/constraints.md
  - workflow: docs/how-to/whole_workflow.md
  - spec/notes: docs/how-to/legal_pages_github_pages.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: 法務URLを安定公開し、ストア審査でのリンク不達を防ぐ

---

## 3. 変更点（What / REQUIRED）
- `docs/how-to/legal_pages_github_pages.md` のPages設定を `main:/docs` から `gh-pages:/` に修正
- `gh-pages` への同期手順を追記

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 機能: 法務ページ運用手順
- 影響する層:
  - [x] Free
  - [x] Pro
  - [ ] 両方

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし
- 移行（migration）が必要:
  - [x] なし

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [x] なし
- 端末/OS差分の懸念:
  - [x] なし

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [ ] pnpm type-check（結果：未実施）
- CI（GitHub Actions）:
  - [ ] 全部 ✅（確認待ち）

### 6-2. 手動確認
1. `gh api /repos/doooooraku/Repolog/pages` で source が `gh-pages` であることを確認
2. `https://doooooraku.github.io/Repolog/privacy/` が 200 を返すことを確認
3. `https://doooooraku.github.io/Repolog/terms/` が 200 を返すことを確認
- 期待結果: 法務URLが常時到達可能
- 実際結果: 期待通り

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] 運用手順が変わる → docs/how-to/legal_pages_github_pages.md を更新
- [x] どれも不要（理由：外部仕様/運用/テスト観点に影響なし、内部リファクタのみ）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク
- 想定リスク: `gh-pages` 同期漏れ
- 検知方法: URLヘルスチェック
- 影響の大きさ:
  - [x] 低

### 9-2. ロールバック
- 戻し方: このPRをrevert

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲を書いた
- [x] 動作確認を記載した
- [x] CIが通った（または理由明記）
- [x] docs影響を判定し更新した
- [x] リスクとロールバックを書いた
