### PR TITLE
chore: restore type-check and integrate CI gate (#36)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,3 +31,5 @@ jobs:
         run: pnpm lint
       - name: Test
         run: pnpm test
+      - name: Type check
+        run: pnpm type-check

--- a/app.config.ts
+++ b/app.config.ts
@@ -31,13 +31,20 @@ const SUPPORTED_LOCALES = [
 const toBoolean = (value?: string) =>
   value === '1' || value === 'true' || value === 'TRUE';
 
-const ensurePlugin = (plugins: ExpoConfig['plugins'] = [], name: string, config?: unknown) => {
+type ExpoPluginList = NonNullable<ExpoConfig['plugins']>;
+type ExpoPluginEntry = ExpoPluginList[number];
+
+const ensurePlugin = (plugins: ExpoPluginList = [], name: string, config?: unknown): ExpoPluginList => {
   const exists = plugins.some((plugin) => {
     if (Array.isArray(plugin)) return plugin[0] === name;
     return plugin === name;
   });
   if (exists) return plugins;
-  return config ? [...plugins, [name, config]] : [...plugins, name];
+  if (config === undefined) {
+    return [...plugins, name];
+  }
+  const pluginWithConfig: ExpoPluginEntry = [name, config];
+  return [...plugins, pluginWithConfig];
 };
 
 export default ({ config }: ConfigContext): ExpoConfig => {
@@ -84,6 +91,8 @@ export default ({ config }: ConfigContext): ExpoConfig => {
 
   return {
     ...config,
+    name: config.name ?? 'Repolog',
+    slug: config.slug ?? 'repolog',
     android: {
       ...config.android,
       permissions: nextPermissions,

--- a/docs/how-to/testing.md
+++ b/docs/how-to/testing.md
@@ -24,29 +24,28 @@
 
 Repolog の scripts（例）：
 - `pnpm lint`
+- `pnpm type-check`
 - `pnpm test`
 - `pnpm test:e2e`（Maestro smoke）
-※ 型チェックを使う場合は `type-check` を scripts に追加する
 
 > How-to は「コマンド暗記」より  
 > **“ここを見れば最新版”** を固定してリンクする方がズレません。
 
 ---
 
-## 2. 最短ルート：まずは「CIと同じ3つ」
+## 2. 最短ルート：まずは「CIと同じ4つ」
 PR前に最低限これを通します（CIでも必ず走る）。
 
 ```bash
 pnpm install --frozen-lockfile
 pnpm lint
 pnpm test
-````
-
-（型チェックを運用している場合）
-
-```bash
 pnpm type-check
 ```
+
+> `pnpm type-check` はアプリ本体を対象にします。  
+> `docs/reference/UI_Figma` は「Figma由来の別コード束」なので、ルートの型検査から除外しています。  
+> UI_Figma 側を編集したときは `docs/reference/UI_Figma` で個別に `npm run build` して確認します。
 
 > もし「まだテストが1本も無い」状態なら  
 > まずは **最低限のテストを1本追加**するのが本筋。  
@@ -64,7 +63,7 @@ pnpm type-check
 * `pnpm lint`
 
   * ESLintで「書き方のルール違反」を見つける（早い・安い）
-* `pnpm type-check`（scriptsにある場合）
+* `pnpm type-check`
 
   * TypeScriptの型チェック（実行しなくてもバグを見つける）
 * `pnpm test`
@@ -112,7 +111,7 @@ pnpm test:e2e
 CIが落ちたステップだけを、まずローカルで叩く：
 
 * Lintで落ちた → `pnpm lint`
-* 型で落ちた → `pnpm type-check`（運用している場合）
+* 型で落ちた → `pnpm type-check`
 * Jestで落ちた → `pnpm test`
 * E2Eで落ちた → `pnpm test:e2e`
 
@@ -145,7 +144,7 @@ CIが落ちたステップだけを、まずローカルで叩く：
 * 対処
 
  1. 最初のエラーから直す（連鎖するから）
- 2. 直したら `pnpm type-check`（運用している場合）
+ 2. 直したら `pnpm type-check`
 
 ---
 
@@ -203,7 +202,7 @@ CIが落ちたステップだけを、まずローカルで叩く：
 ## 8. 最後のチェックリスト（PR前）
 
 * [ ] `pnpm lint` OK
-* [ ] `pnpm type-check` OK（運用している場合）
+* [ ] `pnpm type-check` OK
 * [ ] `pnpm test` OK
 * [ ] 必要なら `pnpm test:e2e` OK
 * [ ] 受け入れ条件が満たされた（PR本文に証拠を書く）

--- a/src/features/pdf/pdfService.ts
+++ b/src/features/pdf/pdfService.ts
@@ -1,6 +1,5 @@
 import { Platform } from 'react-native';
-import * as FileSystem from 'expo-file-system';
-import { StorageAccessFramework } from 'expo-file-system';
+import * as LegacyFileSystem from 'expo-file-system/legacy';
 import * as Print from 'expo-print';
 import * as Sharing from 'expo-sharing';
 
@@ -37,15 +36,19 @@ export async function generatePdfFile(input: PdfGenerateInput) {
 }
 
 async function savePdfAndroid(uri: string, fileName: string) {
-  const permissions = await StorageAccessFramework.requestDirectoryPermissionsAsync();
+  const permissions = await LegacyFileSystem.StorageAccessFramework.requestDirectoryPermissionsAsync();
   if (!permissions.granted) return false;
-  const targetUri = await StorageAccessFramework.createFileAsync(
+  const targetUri = await LegacyFileSystem.StorageAccessFramework.createFileAsync(
     permissions.directoryUri,
     fileName,
     'application/pdf',
   );
-  const base64 = await FileSystem.readAsStringAsync(uri, { encoding: 'base64' });
-  await FileSystem.writeAsStringAsync(targetUri, base64, { encoding: 'base64' });
+  const base64 = await LegacyFileSystem.readAsStringAsync(uri, {
+    encoding: LegacyFileSystem.EncodingType.Base64,
+  });
+  await LegacyFileSystem.writeAsStringAsync(targetUri, base64, {
+    encoding: LegacyFileSystem.EncodingType.Base64,
+  });
   return true;
 }
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -13,5 +13,8 @@
     "**/*.tsx",
     ".expo/types/**/*.ts",
     "expo-env.d.ts"
+  ],
+  "exclude": [
+    "docs/reference/UI_Figma"
   ]
 }


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
TypeScript の型検査を復旧し、CI に `pnpm type-check` を追加しました。あわせて UI_Figma の扱いを docs に明文化しました。

---

## 0. 種別（REQUIRED）
- [x] chore（雑務：依存更新など）
- [x] docs（ドキュメント）

---

## 1. 関連リンク（REQUIRED）
- Issue: #36
- 参照:
  - constraints: docs/reference/constraints.md
  - workflow: docs/how-to/whole_workflow.md
  - testing: docs/how-to/testing.md

---

## 2. 目的（Why / REQUIRED）
- `pnpm type-check` が失敗しており、静的品質ゲートとして機能していなかったため。
- UI_Figma コード束が本体型検査に混入していたため、運用境界を明示して再発防止するため。

---

## 3. 変更点（What / REQUIRED）
- `tsconfig.json`: `docs/reference/UI_Figma` を root type-check の対象外に設定。
- `app.config.ts`: Expo plugin 配列の型を `ExpoConfig` に整合させ、`name/slug` の必須型を保証。
- `src/features/pdf/pdfService.ts`: SAF 利用を `expo-file-system/legacy` に切り替え（型定義と実装を整合）。
- `.github/workflows/ci.yml`: `pnpm type-check` を CI に追加。
- `docs/how-to/testing.md`: UI_Figma の型検査ポリシーを明文化。

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト
- [x] pnpm lint（✅）
- [x] pnpm test（✅）
- [x] pnpm type-check（✅）

実行コマンド:
```bash
pnpm install --frozen-lockfile
pnpm lint
pnpm test
pnpm type-check
```

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] 運用手順が変わる → `docs/how-to/testing.md` を更新
- [x] テスト観点が変わる → CIに type-check を追加

---

## 9. リスク評価 & ロールバック（REQUIRED）
- 想定リスク: 既存ブランチで type-check 落ちが顕在化する可能性
- 検知方法: PR CI の `Type check` ステップ
- 戻し方: `ci.yml` の Type check ステップを revert

---

Closes #36
