### PR TITLE
docs: add main branch protection verification steps (#39)

### DIFF
--- a/docs/how-to/git_workflow.md
+++ b/docs/how-to/git_workflow.md
@@ -328,6 +328,22 @@ git push
 
 ---
 
+### 5.3 ブランチ保護が効いているか不安
+
+* 設定確認（GitHub CLI）
+
+```bash
+gh api repos/doooooraku/Repolog/branches/main/protection
+```
+
+* 期待する状態
+  * `required_status_checks.contexts` に `test` がある
+  * `required_pull_request_reviews` が存在する（mainへ直接pushせずPR経由）
+  * `allow_force_pushes.enabled` が `false`
+  * `allow_deletions.enabled` が `false`
+
+---
+
 ## 6. 付録：コマンド辞典（超ざっくり）
 
 * `git status`：いまの状態を見る

--- a/docs/how-to/whole_workflow.md
+++ b/docs/how-to/whole_workflow.md
@@ -169,6 +169,10 @@ Repolog を **「仕様→Issue→実装→テスト→PR→マージ→リリ�
 * **INPUT**：Issue、差分、CI結果、PRテンプレ
 * **OUTPUT**：PR
 * **完了条件**：Required checks が全部通る（ブランチ保護で強制）
+* **確認コマンド（GitHub CLI）**：
+  `gh api repos/doooooraku/Repolog/branches/main/protection`
+  - `required_status_checks.contexts` に `test` が含まれる
+  - `required_pull_request_reviews` が有効（PR経由必須）
 * **担当**：Codex
 
 ### 工程W-11：マージ（mainに反映）


### PR DESCRIPTION
## 概要（1〜3行 / REQUIRED）
Issue #39 の受け入れ条件に合わせて、main の保護ルール確認手順を docs/how-to に追加しました。

## 1. 関連リンク（REQUIRED）
- Issue: #39
- 参照:
  - docs/reference/constraints.md
  - docs/how-to/whole_workflow.md
  - docs/how-to/git_workflow.md

## 3. 変更点（What / REQUIRED）
- `docs/how-to/whole_workflow.md` に W-10 の確認コマンドを追加
- `docs/how-to/git_workflow.md` に「5.3 ブランチ保護確認」節を追加

## 6. 動作確認（How to test / REQUIRED）
- [x] pnpm lint（✅）
- [x] pnpm test（✅）
- [x] pnpm type-check（✅）

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] 運用手順が変わる → docs/how-to を更新

Closes #39
