### PR TITLE
test: add maestro flows for photo edit and language persistence (#37)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -94,10 +94,11 @@ export default function HomeScreen() {
     ]);
   };
 
-  const renderItem = ({ item }: { item: Report }) => {
+  const renderItem = ({ item, index }: { item: Report; index: number }) => {
     const summary = meta[item.id] ?? {};
     return (
       <Pressable
+        testID={`e2e_home_report_card_${index}`}
         style={styles.card}
         onPress={() => router.push(`/reports/${item.id}`)}>
         {summary.firstPhotoUri ? (
@@ -117,8 +118,10 @@ export default function HomeScreen() {
           <Text style={styles.cardSub}>{item.createdAt.replace('T', ' ').slice(0, 16)}</Text>
           <View style={styles.cardRow}>
             <Text style={styles.cardMeta}>
+              {/* Keep count explicit for E2E assertions. */}
               {summary.photoCount ?? 0} {t.reportPhotosLabel}
             </Text>
+            <Text testID={`e2e_home_report_${index}_photo_count_${summary.photoCount ?? 0}`} />
             <Pressable onPress={() => handleDelete(item)}>
               <Text style={styles.deleteText}>{t.deleteAction}</Text>
             </Pressable>
@@ -137,10 +140,11 @@ export default function HomeScreen() {
   }
 
   return (
-    <View style={styles.container}>
+    <View style={styles.container} testID="e2e_home_screen">
       <View style={styles.headerRow}>
         <Text style={styles.title}>{t.homeTitle}</Text>
         <Pressable
+          testID="e2e_open_settings"
           onPress={() => router.push('/settings')}
           style={styles.iconButton}>
           <IconSymbol name="gearshape.fill" size={20} color="#111" />
@@ -156,7 +160,10 @@ export default function HomeScreen() {
         <View style={styles.empty}>
           <Text style={styles.emptyTitle}>{t.homeEmptyTitle}</Text>
           <Text style={styles.emptyBody}>{t.homeEmptyBody}</Text>
-          <Pressable style={styles.newButton} onPress={() => router.push('/reports/new')}>
+          <Pressable
+            testID="e2e_home_create_report"
+            style={styles.newButton}
+            onPress={() => router.push('/reports/new')}>
             <Text style={styles.newButtonText}>{t.homeCreateReport}</Text>
           </Pressable>
         </View>

--- a/docs/how-to/testing.md
+++ b/docs/how-to/testing.md
@@ -82,17 +82,21 @@ pnpm test:e2e
 
 ### 3.1 何が起きる？
 
-* Maestro が `maestro/flows/smoke.yml` を実行
-* アプリを起動して、最低限の操作ができるかを確認する（スモークテスト）
+* Maestro が `maestro/flows/*.yml` を順番に実行する
+  - `smoke.yml`（Home↔Settings）
+  - `report-photo-edit.yml`（写真追加/並び替え/削除/再表示）
+  - `settings-language-persistence.yml`（言語保持）
+* アプリを起動して、主要導線の回帰を確認する
 
 ### 3.1.1 まず最初に直すべきこと（重要）
-* `maestro/flows/smoke.yml` の `appId: "CHANGE_ME_APP_ID"` を **実アプリのID**に書き換える
+* `maestro/flows/*.yml` の `appId` が実アプリID（`com.dooooraku.repolog`）と一致しているか確認する
 * E2Eで使う `testID` が実装側にあるか確認する（無ければ追加）
 
 ### 3.2 ここが注意（詰まりやすい）
 
 * 端末/エミュレータが必要
-* 初回は Maestro のインストールが必要になることがある
+* 初回は Maestro CLI のインストールが必要
+  - 例: `curl -Ls \"https://get.maestro.mobile.dev\" | bash`
 * CIでは条件付きで走る設定になっている場合がある（SecretsやAPKの有無）
 
 ---

--- a/maestro/flows/report-photo-edit.yml
+++ b/maestro/flows/report-photo-edit.yml
@@ -1,0 +1,67 @@
+appId: "com.dooooraku.repolog"
+name: "E2E - report photo edit flow"
+tags:
+  - e2e
+  - report
+
+steps:
+  - launchApp:
+      clearState: true
+      label: "クリーン起動"
+  - assertVisible:
+      id: "e2e_home_screen"
+      label: "Homeを表示"
+  - tapOn:
+      id: "e2e_home_create_report"
+      label: "新規レポートを作成"
+  - assertVisible:
+      id: "e2e_report_editor_screen"
+      label: "編集画面を表示"
+  - tapOn:
+      id: "e2e_seed_photos"
+      label: "E2E用サンプル写真を追加"
+  - assertVisible:
+      id: "e2e_photo_count_3"
+      label: "写真3枚を確認"
+  - assertVisible:
+      id: "e2e_photo_slot_0_seed_1"
+  - assertVisible:
+      id: "e2e_photo_slot_1_seed_2"
+  - assertVisible:
+      id: "e2e_photo_slot_2_seed_3"
+  - dragAndDrop:
+      from:
+        id: "e2e_photo_slot_0_seed_1"
+      to:
+        id: "e2e_photo_slot_2_seed_3"
+      label: "seed-1 を末尾へ移動"
+  - assertVisible:
+      id: "e2e_photo_slot_0_seed_2"
+      label: "並び替え後の先頭を確認"
+  - assertVisible:
+      id: "e2e_photo_slot_2_seed_1"
+      label: "並び替え後の末尾を確認"
+  - tapOn:
+      id: "e2e_photo_delete_now_0"
+      label: "先頭写真を削除（E2E即時削除）"
+  - assertVisible:
+      id: "e2e_photo_count_2"
+      label: "削除後2枚を確認"
+  - tapOn:
+      id: "e2e_report_back"
+      label: "Homeへ戻る"
+  - assertVisible:
+      id: "e2e_home_screen"
+  - assertVisible:
+      id: "e2e_home_report_0_photo_count_2"
+      label: "Home上でも写真枚数を確認"
+  - tapOn:
+      id: "e2e_home_report_card_0"
+      label: "再度レポートを開く"
+  - assertVisible:
+      id: "e2e_report_editor_screen"
+  - assertVisible:
+      id: "e2e_photo_slot_0_seed_3"
+      label: "再表示で並びが維持される"
+  - assertVisible:
+      id: "e2e_photo_slot_1_seed_1"

--- a/maestro/flows/settings-language-persistence.yml
+++ b/maestro/flows/settings-language-persistence.yml
@@ -1,0 +1,44 @@
+appId: "com.dooooraku.repolog"
+name: "E2E - language persistence"
+tags:
+  - e2e
+  - settings
+
+steps:
+  - launchApp:
+      clearState: true
+      label: "クリーン起動"
+  - assertVisible:
+      id: "e2e_home_screen"
+  - tapOn:
+      id: "e2e_open_settings"
+      label: "設定を開く"
+  - assertVisible:
+      id: "e2e_settings_screen"
+  - tapOn:
+      id: "e2e_language_toggle"
+      label: "言語リストを開く"
+  - tapOn:
+      id: "e2e_language_option_zh_hans"
+      label: "中国語(簡体)を選択"
+  - assertVisible:
+      id: "e2e_current_language_zh_hans"
+      label: "設定直後の反映を確認"
+  - stopApp:
+      label: "アプリ終了"
+  - launchApp:
+      clearState: false
+      label: "状態維持で再起動"
+  - assertVisible:
+      id: "e2e_home_screen"
+  - tapOn:
+      id: "e2e_open_settings"
+  - assertVisible:
+      id: "e2e_settings_screen"
+  - tapOn:
+      id: "e2e_language_toggle"
+  - assertVisible:
+      id: "e2e_current_language_zh_hans"
+      label: "再起動後も保持される"
+  - assertVisible:
+      id: "e2e_language_selected_zh_hans"

--- a/maestro/flows/smoke.yml
+++ b/maestro/flows/smoke.yml
@@ -1,73 +1,24 @@
-# maestro/flows/smoke.yml
-# App Factory 共通スモークテスト
-
-appId: "CHANGE_ME_APP_ID"     # ★各アプリの Application ID / Bundle ID に書き換える
-name: "Smoke - main flow"    # テスト名（レポートでの表示名）
+appId: "com.dooooraku.repolog"
+name: "Smoke - home and settings"
 tags:
-  - smoke                    # 簡易テストであることを示すタグ
+  - smoke
 
 steps:
-  # 1. アプリ起動
   - launchApp:
       clearState: true
-      label: "アプリをクリーン起動する"
-
-  # 2. ホーム画面表示確認
+      label: "クリーン起動"
   - assertVisible:
       id: "e2e_home_screen"
-      label: "ホーム画面（e2e_home_screen）が表示されていることを確認"
-
-  # 3. 主要機能を 1 回実行
-  - tapOn:
-      id: "e2e_main_action"
-      label: "主要機能を実行するボタンをタップ"
-
-  - assertVisible:
-      id: "e2e_main_result"
-      optional: true
-      label: "主要機能の結果表示（e2e_main_result）が見えていることを確認（あれば確認）"
-
-  # 4. 課金画面（RevenueCat）を開く（ある場合だけ）
-  - tapOn:
-      id: "e2e_open_premium"
-      optional: true
-      label: "課金画面への入口（e2e_open_premium）をタップ（存在する場合だけ実行）"
-
-  - assertVisible:
-      id: "e2e_premium_screen"
-      optional: true
-      label: "課金画面（e2e_premium_screen）が開いたことを確認（存在する場合だけ確認）"
-
-  # 5. 広告を開く（ある場合だけ）
-  - tapOn:
-      id: "e2e_open_ad"
-      optional: true
-      label: "広告表示のトリガー（e2e_open_ad）をタップ（存在する場合だけ実行）"
-
-  - assertVisible:
-      id: "e2e_ad_container"
-      optional: true
-      label: "広告コンテナ（e2e_ad_container）が表示されていることを確認（存在する場合だけ確認）"
-
-  # 6. 設定画面を開く
+      label: "Homeを表示"
   - tapOn:
       id: "e2e_open_settings"
-      label: "設定画面への入口（e2e_open_settings）をタップ"
-
+      label: "設定を開く"
   - assertVisible:
       id: "e2e_settings_screen"
-      label: "設定画面（e2e_settings_screen）が表示されていることを確認"
-
-  # 7. モーダルや画面を閉じて終了
+      label: "Settingsを表示"
   - tapOn:
-      id: "e2e_close_modal"
-      optional: true
-      label: "モーダルを閉じるボタン（e2e_close_modal）があればタップ"
-
-  - tapOn:
-      id: "e2e_back_to_home"
-      optional: true
-      label: "ホームへ戻るボタン（e2e_back_to_home）があればタップ"
-
-  - stopApp:
-      label: "アプリを終了する"
+      id: "e2e_back_home"
+      label: "Homeへ戻る"
+  - assertVisible:
+      id: "e2e_home_screen"
+      label: "Homeへ復帰"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "lint": "eslint .",
     "type-check": "tsc --noEmit",
     "test": "jest --passWithNoTests",
-    "test:e2e": "maestro test maestro/flows/smoke.yml",
+    "test:e2e": "maestro test maestro/flows",
     "prebuild": "expo prebuild",
     "build:android": "expo prebuild --platform android && cd android && ./gradlew bundleRelease"
   },

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -38,6 +38,8 @@ const LANGUAGE_OPTIONS: { code: Lang; labelKey: TranslationKey }[] = [
   { code: 'sv', labelKey: 'languageNameSv' },
 ];
 
+const toLangTestId = (code: string) => code.toLowerCase().replace(/-/g, '_');
+
 export default function SettingsScreen() {
   const router = useRouter();
   const { t, lang, setLang } = useTranslation();
@@ -76,9 +78,9 @@ export default function SettingsScreen() {
   };
 
   return (
-    <ScrollView contentContainerStyle={styles.container}>
+    <ScrollView contentContainerStyle={styles.container} testID="e2e_settings_screen">
       <View style={styles.headerRow}>
-        <Pressable onPress={() => router.back()} style={styles.backButton}>
+        <Pressable testID="e2e_back_home" onPress={() => router.back()} style={styles.backButton}>
           <Text style={styles.backText}>{'‹'}</Text>
         </Pressable>
         <Text style={styles.headerTitle}>{t.settings}</Text>
@@ -88,9 +90,12 @@ export default function SettingsScreen() {
         <Text style={styles.sectionTitle}>{t.settingsSectionGeneral}</Text>
         <Text style={styles.sectionBody}>{t.languageChange}</Text>
         <Pressable
+          testID="e2e_language_toggle"
           onPress={() => setShowLanguages((prev) => !prev)}
           style={styles.rowBetween}>
-          <Text style={styles.valueText}>{`${t.currentLanguage}: ${currentLanguageLabel}`}</Text>
+          <Text
+            style={styles.valueText}
+            testID={`e2e_current_language_${toLangTestId(lang)}`}>{`${t.currentLanguage}: ${currentLanguageLabel}`}</Text>
           <Text style={styles.chevron}>{showLanguages ? '▲' : '▼'}</Text>
         </Pressable>
         {showLanguages && (
@@ -100,12 +105,19 @@ export default function SettingsScreen() {
               return (
                 <Pressable
                   key={option.code}
+                  testID={`e2e_language_option_${toLangTestId(option.code)}`}
                   onPress={() => setLang(option.code)}
                   style={[styles.optionRow, active && styles.optionRowActive]}>
                   <Text style={[styles.optionText, active && styles.optionTextActive]}>
                     {t[option.labelKey] ?? option.code}
                   </Text>
-                  {active && <Text style={styles.optionCheck}>✓</Text>}
+                  {active && (
+                    <Text
+                      style={styles.optionCheck}
+                      testID={`e2e_language_selected_${toLangTestId(option.code)}`}>
+                      ✓
+                    </Text>
+                  )}
                 </Pressable>
               );
             })}


### PR DESCRIPTION
## 概要（1〜3行 / REQUIRED）
Issue #37 に対応し、Maestro E2Eフロー（写真編集・言語保持）を追加しました。あわせて対象画面へ `testID` を実装し、既存 smoke フローも実データに更新しました。

## 0. 種別（REQUIRED）
- [x] test（テスト追加/修正）
- [x] docs（ドキュメント）

## 1. 関連リンク（REQUIRED）
- Issue: #37
- 参照:
  - docs/reference/functional_spec.md
  - docs/reference/basic_spec.md
  - docs/how-to/testing.md

## 2. 目的（Why / REQUIRED）
- 写真並べ替え/削除フローのE2E回帰が無かったため。
- 言語設定の再起動保持をE2Eで固定するため。

## 3. 変更点（What / REQUIRED）
- 新規フロー: `maestro/flows/report-photo-edit.yml`
- 新規フロー: `maestro/flows/settings-language-persistence.yml`
- 既存 `smoke.yml` を Repolog 実アプリID/実導線に更新
- `test:e2e` を `maestro/flows` 全体実行へ変更
- Home / Settings / ReportEditor に E2E用 `testID` を追加
- ReportEditor に `__DEV__` 限定のE2Eシード導線を追加
- `docs/how-to/testing.md` を新フロー構成に更新

## 6. 動作確認（How to test / REQUIRED）
- [x] pnpm lint（✅）
- [x] pnpm test（✅）
- [x] pnpm type-check（✅）
- [ ] pnpm test:e2e（❌: `maestro` コマンド未導入環境）

実行ログ（E2E失敗要因）:
- `sh: 1: maestro: not found`

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] テスト運用手順が変わる → `docs/how-to/testing.md` 更新
- [x] テスト観点が変わる → Maestroフロー追加

## 9. リスク評価 & ロールバック（REQUIRED）
- 想定リスク: E2E専用UIが通常導線へ漏れる
- 検知方法: `__DEV__` 条件下のみ描画で確認
- 戻し方: E2E専用導線のrevert（フローは維持）

Closes #37
