### PR TITLE
feat: close report editor parity gaps (auto name seed + photo delete undo) (#42)

### DIFF
--- a/__tests__/photoOrderUtils.test.ts
+++ b/__tests__/photoOrderUtils.test.ts
@@ -3,6 +3,7 @@ import {
   isPhotoOrderNormalized,
   normalizePhotoOrder,
   removePhotoAndNormalize,
+  restorePhotoAtIndexAndNormalize,
 } from '@/src/features/reports/photoOrderUtils';
 
 const buildPhoto = (id: string, orderIndex: number): Photo => ({
@@ -32,6 +33,15 @@ describe('photoOrderUtils', () => {
 
     expect(result.map((photo) => photo.id)).toEqual(['p1', 'p3']);
     expect(result.map((photo) => photo.orderIndex)).toEqual([0, 1]);
+  });
+
+  test('restorePhotoAtIndexAndNormalize inserts photo at given position', () => {
+    const photos = [buildPhoto('p1', 0), buildPhoto('p3', 1)];
+
+    const result = restorePhotoAtIndexAndNormalize(photos, buildPhoto('p2', 99), 1);
+
+    expect(result.map((photo) => photo.id)).toEqual(['p1', 'p2', 'p3']);
+    expect(result.map((photo) => photo.orderIndex)).toEqual([0, 1, 2]);
   });
 
   test('isPhotoOrderNormalized validates index continuity', () => {

--- a/src/core/i18n/locales/en.ts
+++ b/src/core/i18n/locales/en.ts
@@ -286,6 +286,8 @@ const baseEn = {
   photoDeleteConfirmTitle: 'Delete photo?',
   photoDeleteConfirmBody: 'This photo will be removed from this report.',
   photoDeleteFailed: 'Failed to delete photo.',
+  photoDeletedNotice: 'Photo removed.',
+  undoAction: 'Undo',
   homeTitle: 'Home',
   homeSearchPlaceholder: 'Search reports...',
   homePinnedSection: 'Pinned',

--- a/src/db/reportRepository.ts
+++ b/src/db/reportRepository.ts
@@ -99,6 +99,20 @@ export async function searchReports(query: string): Promise<Report[]> {
   return rows.map(toReport);
 }
 
+export async function getLatestReportName(): Promise<string | null> {
+  const db = await getDb();
+  const row = await db.getFirstAsync<{ report_name: string | null }>(
+    `SELECT report_name
+       FROM reports
+      WHERE report_name IS NOT NULL
+        AND TRIM(report_name) != ''
+      ORDER BY updated_at DESC
+      LIMIT 1`,
+  );
+  const reportName = row?.report_name?.trim() ?? '';
+  return reportName.length > 0 ? reportName : null;
+}
+
 export async function getReportById(id: string): Promise<Report | null> {
   const db = await getDb();
   const row = await db.getFirstAsync<ReportRow>(

--- a/src/features/reports/photoOrderUtils.ts
+++ b/src/features/reports/photoOrderUtils.ts
@@ -11,6 +11,17 @@ export function removePhotoAndNormalize(photos: Photo[], photoId: string): Photo
   return normalizePhotoOrder(photos.filter((photo) => photo.id !== photoId));
 }
 
+export function restorePhotoAtIndexAndNormalize(
+  photos: Photo[],
+  photo: Photo,
+  targetIndex: number,
+): Photo[] {
+  const index = Math.max(0, Math.min(targetIndex, photos.length));
+  const next = [...photos];
+  next.splice(index, 0, photo);
+  return normalizePhotoOrder(next);
+}
+
 export function isPhotoOrderNormalized(photos: Photo[]): boolean {
   return photos.every((photo, index) => photo.orderIndex === index);
 }


### PR DESCRIPTION
## Summary
- seed report name input on new report creation using the latest non-empty report name
- add one-shot undo flow for photo deletion (4s window) with order restoration
- finalize pending deletion before save/preview/back/add/reorder to avoid state conflicts
- add regression utility and test for restoring a photo at a target index

## Changes
- add `getLatestReportName` in `src/db/reportRepository.ts`
- extend `src/features/reports/photoOrderUtils.ts` with `restorePhotoAtIndexAndNormalize`
- implement pending delete + undo UI/state in `src/features/reports/ReportEditorScreen.tsx`
- add i18n keys in `src/core/i18n/locales/en.ts`
- add Jest regression test in `__tests__/photoOrderUtils.test.ts`

## Verification
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm test`
- `pnpm type-check`

Closes #42
