### PR TITLE
feat: show weather status on home cards (#62)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -40,6 +40,14 @@ const sanitizeTestIdToken = (value: string) =>
     .replace(/[^a-z0-9]+/g, '_')
     .replace(/^_+|_+$/g, '');
 
+const weatherSymbolMap: Record<Report['weather'], string> = {
+  sunny: '☀️',
+  cloudy: '☁️',
+  rainy: '🌧️',
+  snowy: '❄️',
+  none: '—',
+};
+
 export default function HomeScreen() {
   const router = useRouter();
   const { t } = useTranslation();
@@ -171,7 +179,14 @@ export default function HomeScreen() {
               <Text style={styles.pinText}>{item.pinned ? '★' : '☆'}</Text>
             </Pressable>
           </View>
-          <Text style={styles.cardSub}>{item.createdAt.replace('T', ' ').slice(0, 16)}</Text>
+          <View style={styles.cardRow}>
+            <Text style={styles.cardSub}>{item.createdAt.replace('T', ' ').slice(0, 16)}</Text>
+            <Text
+              testID={`e2e_home_report_${index}_weather_${item.weather}`}
+              style={styles.cardWeather}>
+              {weatherSymbolMap[item.weather]}
+            </Text>
+          </View>
           <View style={styles.cardRow}>
             <Text style={styles.cardMeta}>
               {/* Keep count explicit for E2E assertions. */}
@@ -511,6 +526,10 @@ const styles = StyleSheet.create({
   cardSub: {
     fontSize: 12,
     color: '#777',
+  },
+  cardWeather: {
+    fontSize: 14,
+    color: '#333',
   },
   cardMeta: {
     fontSize: 12,

--- a/maestro/flows/report-photo-edit.yml
+++ b/maestro/flows/report-photo-edit.yml
@@ -55,6 +55,9 @@ steps:
   - assertVisible:
       id: "e2e_home_report_0_photo_count_2"
       label: "Home上でも写真枚数を確認"
+  - assertVisible:
+      id: "e2e_home_report_0_weather_none"
+      label: "Home上で天気状態を確認"
   - tapOn:
       id: "e2e_home_create_report_fab"
       label: "既存レポートあり状態で新規作成導線を確認"


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
Homeカードに天気状態（☀️/☁️/🌧️/❄️/—）を表示し、`functional_spec` F-03 との整合を取りました。E2Eフローにも天気表示確認を追加しました。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [x] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [x] test（テスト追加/修正）
- [ ] docs（ドキュメント）
- [ ] chore（雑務：依存更新など）
- [ ] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #62
- 参照:
  - docs/reference/functional_spec.md
  - docs/reference/basic_spec.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: Homeでレポートの状態を素早く把握できる
- 再現条件（ギャップ）: Homeカードに天気情報が表示されない

---

## 3. 変更点（What / REQUIRED）
- Homeカード描画に `weatherSymbolMap` を導入
- Homeカードへ天気表示を追加し、E2E検証用 `testID` を付与
- Maestro `report-photo-edit.yml` に天気表示の確認ステップを追加

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] AC1: Homeカードに設定済み天気が表示される
- [x] AC2: weather=none の場合は `—` が表示される
- [x] AC3: lint/test/type-check が成功する

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [ ] pnpm test:e2e（結果：未実行）
- [x] pnpm type-check（結果：✅）
- CI（GitHub Actions）:
  - [ ] 全部 ✅（PR作成後確認）

### 6-2. 手動確認
1. レポートを作成してHomeへ戻る
2. 対象カードに天気記号が表示されることを確認

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] どれも不要（理由：既存仕様への準拠実装）
- [x] テスト観点が変わる → maestro/flows/report-photo-edit.yml 更新

---

## 9. リスク評価 & ロールバック（REQUIRED）
- 想定リスク: カード表示情報が増え視認性が低下する可能性
- 検知方法: Homeカードの手動確認
- 影響の大きさ: 低
- ロールバック: このPRをrevert
