### PR TITLE
docs: add release tag and release-note workflow (#64)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -29,6 +29,7 @@
 - `docs/how-to/*`
   - Issue -> PR -> CI -> Release の「やり方」
   - 例：`docs/how-to/legal_pages_github_pages.md`（法務ページ公開とリンク運用）
+  - 例：`docs/how-to/release_notes_template.md`（タグ命名規則とReleaseノート雛形）
 
 ---
 

--- a/docs/how-to/android_ビルド手順.md
+++ b/docs/how-to/android_ビルド手順.md
@@ -1,6 +1,33 @@
 # Android_ビルド手順（Debug運用 / Release提出）
 最終更新: 2026-01-19（JST）
 
+## 1. タグ運用（リリース可視化）
+リリース前に必ずタグとノートを作成する。  
+正は `docs/how-to/release_notes_template.md`。
+
+### 1-1. 候補版タグ（RC）を作る
+git switch main
+git pull --ff-only origin main
+git tag -a v1.0.0-rc.1 -m "Repolog v1.0.0-rc.1"
+git push origin v1.0.0-rc.1
+
+意味：
+- git tag -a：注釈付きタグを作る（履歴として残る）
+- v1.0.0-rc.1：候補版（release candidate）
+- git push origin <tag>：タグをGitHubへ公開
+
+### 1-2. GitHub Release を作る
+gh release create v1.0.0-rc.1 \
+  --repo doooooraku/Repolog \
+  --title "Repolog v1.0.0-rc.1" \
+  --notes-file docs/how-to/release_notes_template.md \
+  --prerelease
+
+意味：
+- gh release create：Releaseを作る
+- --prerelease：候補版として扱う（本番版ではない）
+- --notes-file：テンプレから本文を読み込む
+
 ## 2. Debug（開発用）: ExpoGoを活用しエミュレータでデバッグ
 ### 2-1. 全体の流れ（一本道）
 1) エミュレータ起動（Android Studioなど）

--- a/docs/how-to/ios_ビルド手順.md
+++ b/docs/how-to/ios_ビルド手順.md
@@ -6,13 +6,46 @@
 
 ---
 
-## 1. Debug（開発用）: シミュレータで確認
-### 1-1. 全体の流れ（一本道）
+## 1. タグ運用（リリース可視化）
+リリース前に必ずタグとノートを作成する。  
+正は `docs/how-to/release_notes_template.md`。
+
+### 1-1. 候補版タグ（RC）を作る
+```bash
+git switch main
+git pull --ff-only origin main
+git tag -a v1.0.0-rc.1 -m "Repolog v1.0.0-rc.1"
+git push origin v1.0.0-rc.1
+```
+
+意味：
+- `git tag -a`：注釈付きタグを作る
+- `v1.0.0-rc.1`：候補版（release candidate）
+- `git push origin <tag>`：タグをリモートへ公開
+
+### 1-2. GitHub Release を作る
+```bash
+gh release create v1.0.0-rc.1 \
+  --repo doooooraku/Repolog \
+  --title "Repolog v1.0.0-rc.1" \
+  --notes-file docs/how-to/release_notes_template.md \
+  --prerelease
+```
+
+意味：
+- `gh release create`：Release作成
+- `--prerelease`：候補版扱いで公開
+- `--notes-file`：ノート本文をファイルから読み込み
+
+---
+
+## 2. Debug（開発用）: シミュレータで確認
+### 2-1. 全体の流れ（一本道）
 1) iOS Simulator 起動（Xcode）
 2) Metro 起動
 3) Simulator で動作確認
 
-### 1-2. 手順（超具体）
+### 2-2. 手順（超具体）
 #### Step 0: ルートへ移動
 ```bash
 cd <project-root>
@@ -35,13 +68,11 @@ npx expo start --clear
 - Xcode の Simulator から端末を起動
 - Metro の案内に従って iOS でアプリを開く
 
----
-
-## 2. Release（提出用）: EAS で署名済みビルド
+## 3. Release（提出用）: EAS で署名済みビルド
 > ここは **プロジェクトごとの証明書/プロビジョニング** で差分が出ます。  
 > まずは公式手順を確認してから進める。
 
-### 2-1. “prebuild が必要か？”判定
+### 3-1. “prebuild が必要か？”判定
 ネイティブに効く変更をしたら：
 ```bash
 npx expo prebuild --platform ios
@@ -51,7 +82,7 @@ npx expo prebuild --platform ios
 - `expo prebuild`：ネイティブ（ios/）を設定に合わせて更新
 - `--platform ios`：iOSのみ対象
 
-### 2-2. iOS ビルド（EAS）
+### 3-2. iOS ビルド（EAS）
 ```bash
 eas build -p ios --profile production --local --non-interactive --output=app.ipa
 ```
@@ -64,7 +95,7 @@ eas build -p ios --profile production --local --non-interactive --output=app.ipa
 - `--non-interactive`：対話なし
 - `--output`：成果物名
 
-### 2-3. 提出（EAS Submit を使う場合）
+### 3-3. 提出（EAS Submit を使う場合）
 ```bash
 eas submit -p ios --profile production
 ```
@@ -76,14 +107,14 @@ eas submit -p ios --profile production
 
 ---
 
-## 3. 事前に必要になりやすいもの
+## 4. 事前に必要になりやすいもの
 - Apple Developer Program への登録
 - 証明書 / プロビジョニングプロファイル
 - App Store Connect でのアプリ登録
 
 ---
 
-## 4. 参考（正は公式）
+## 5. 参考（正は公式）
 - Expo EAS Build（iOS）: https://docs.expo.dev/build/introduction/
 - Expo EAS Submit（iOS）: https://docs.expo.dev/submit/introduction/
 - Apple Developer: https://developer.apple.com/

--- a/docs/how-to/release_notes_template.md
+++ b/docs/how-to/release_notes_template.md
@@ -1,0 +1,104 @@
+# release_notes_template.md（タグ運用とリリースノート雛形）
+
+この文書は **How-to（運用手順）** です。  
+「なぜこの運用にしたか」は ADR へ、  
+「いつリリースするか」は Milestone/Project で管理します。
+
+---
+
+## 1. タグ命名ルール（正）
+
+- 候補版（審査前/検証中）: `v<MAJOR>.<MINOR>.<PATCH>-rc.<N>`
+  - 例: `v1.0.0-rc.1`
+- 本番版（公開版）: `v<MAJOR>.<MINOR>.<PATCH>`
+  - 例: `v1.0.0`
+
+補足:
+- SemVer 2.0.0 に合わせて `MAJOR.MINOR.PATCH` を採用する
+- `rc` は release candidate（候補版）の意味
+
+---
+
+## 2. タグ作成コマンド（最短）
+
+```bash
+# 1) mainを最新化
+git switch main
+git pull --ff-only origin main
+
+# 2) 候補版タグを作成
+git tag -a v1.0.0-rc.1 -m "Repolog v1.0.0-rc.1"
+
+# 3) タグをリモートへ送る
+git push origin v1.0.0-rc.1
+```
+
+コマンドの意味:
+- `git tag -a`: 注釈付きタグを作る（誰が何のために切ったか残せる）
+- `-m`: タグの説明文
+- `git push origin <tag>`: タグを GitHub へ公開
+
+---
+
+## 3. GitHub Release 作成コマンド（gh CLI）
+
+```bash
+# 候補版（pre-release）を作成
+gh release create v1.0.0-rc.1 \
+  --repo doooooraku/Repolog \
+  --title "Repolog v1.0.0-rc.1" \
+  --notes-file docs/how-to/release_notes_template.md \
+  --prerelease
+```
+
+```bash
+# 本番版（stable）を作成
+gh release create v1.0.0 \
+  --repo doooooraku/Repolog \
+  --title "Repolog v1.0.0" \
+  --notes-file docs/how-to/release_notes_template.md
+```
+
+コマンドの意味:
+- `gh release create`: GitHub Release を新規作成
+- `--prerelease`: 候補版として公開（本番扱いしない）
+- `--notes-file`: リリースノート本文をファイルから読み込む
+
+---
+
+## 4. リリースノート雛形（このまま使える最小テンプレ）
+
+以下をコピーして、各版ごとに具体値へ置換する。
+
+```md
+# Repolog vX.Y.Z(-rc.N)
+
+## 1. Summary
+- 何を直したか（1〜3行）
+
+## 2. User Impact
+- Freeへの影響:
+- Proへの影響:
+
+## 3. Changes
+- feat:
+- fix:
+- docs/chore:
+
+## 4. Verification
+- pnpm lint: ✅/❌
+- pnpm test: ✅/❌
+- pnpm type-check: ✅/❌
+- Actions URL:
+
+## 5. Rollback
+- 問題時は対象PRをrevertし、前タグへ戻す
+```
+
+---
+
+## 5. 参照（一次情報）
+
+- SemVer 2.0.0: https://semver.org/
+- GitHub Releases: https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases
+- gh release create: https://cli.github.com/manual/gh_release_create

--- a/docs/how-to/whole_workflow.md
+++ b/docs/how-to/whole_workflow.md
@@ -244,10 +244,12 @@ gh api repos/doooooraku/Repolog/issues/<Issue番号>/comments
 
 * **トリガーキー**：mainが安定 / 仕様書から作成するIssue/バグが無くなった
 * **作業内容**：
+  * `docs/how-to/release_notes_template.md` に沿ってリリースノートを作成
+  * `vX.Y.Z-rc.N` または `vX.Y.Z` のタグを作成し、`gh release create` で公開
   * `docs/how-to/android_ビルド手順.md`の実施
   * `docs/how-to/ios_ビルド手順.md`の実施
 * **INPUT**：main、リリースノート、Storeメタ情報
-* **OUTPUT**：TestFlight / Play内部テスト / 本番リリース
+* **OUTPUT**：GitHub Release / TestFlight / Play内部テスト / 本番リリース
 * **完了条件**：ストアの審査/配信が通る。
 * **担当**：人間
 


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
タグ命名規則（`vX.Y.Z-rc.N` / `vX.Y.Z`）とGitHub Releaseノート運用をHow-toとして追加しました。Android/iOSビルド手順と全体ワークフローを同じ基準に揃えました。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [ ] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [ ] test（テスト追加/修正）
- [x] docs（ドキュメント）
- [ ] chore（雑務：依存更新など）
- [x] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #64
- 参照:
  - docs/how-to/whole_workflow.md
  - docs/how-to/android_ビルド手順.md
  - docs/how-to/ios_ビルド手順.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: 統合進捗（どのコミットが配布候補か）をタグ/Releaseで可視化する
- 背景: リポジトリにタグ/Release運用規約がなく、監査可能性が低かった

---

## 3. 変更点（What / REQUIRED）
- `docs/how-to/release_notes_template.md` を新規追加（タグ命名規則・コマンド・ノート雛形）
- `docs/how-to/android_ビルド手順.md` にタグ/Release作成手順を追加
- `docs/how-to/ios_ビルド手順.md` にタグ/Release作成手順を追加
- `docs/how-to/whole_workflow.md` のW-12にタグ/Release手順を追加
- `docs/README.md` に新規How-toを索引登録

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] AC1: タグ命名規則が文書化される
- [x] AC2: リリースノートのテンプレが明記される
- [x] AC3: Android/iOS/全体ワークフローの記述が整合する

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [ ] pnpm test:e2e（結果：未実行）
- [x] pnpm type-check（結果：✅）
- CI（GitHub Actions）:
  - [ ] 全部 ✅（PR作成後確認）

### 6-2. 手動確認
1. `docs/how-to/release_notes_template.md` に規約・コマンド・テンプレがあること
2. Android/iOS/whole_workflow が同じ規約へリンクしていること

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] 運用手順が変わる → docs/how-to を更新
- [x] どれも不要（理由：実装仕様/制約そのものは変更なし）

---

## 9. リスク評価 & ロールバック（REQUIRED）
- 想定リスク: タグ規約だけ先行して実運用が追いつかない
- 検知方法: 次回リリース時の手順逸脱
- 影響の大きさ: 低
- ロールバック: 当該docs変更をrevert

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲を書いた
- [x] 合否が判定できる動作確認を記載
- [ ] CIが通った（PR作成後確認）
- [x] docs影響を判定し更新した
- [x] リスクとロールバックを書いた
