### PR TITLE
docs: add milestone rollover playbook to workflow (#65)

### DIFF
--- a/docs/how-to/whole_workflow.md
+++ b/docs/how-to/whole_workflow.md
@@ -240,6 +240,32 @@ gh api repos/doooooraku/Repolog/issues/<Issue番号>
 gh api repos/doooooraku/Repolog/issues/<Issue番号>/comments
 ```
 
+#### W-11.5 補足：Milestoneの締め処理（毎サイクル）
+
+Milestoneは「未完了Issueが0になった時点」でクローズする。  
+同時に次サイクルのMilestoneを作り、残課題を移す。
+
+```bash
+# 1) 現在のMilestone状態を確認
+gh api repos/doooooraku/Repolog/milestones?state=all
+
+# 2) 次サイクルMilestoneを作成（必要なら）
+gh api repos/doooooraku/Repolog/milestones --method POST \
+  -f title='v1.0 release stabilization (2026-03)' \
+  -f description='Post-RC stabilization items' \
+  -f due_on='2026-03-31T00:00:00Z'
+
+# 3) 未完了Issueを次Milestoneへ移す
+gh issue edit <Issue番号> --repo doooooraku/Repolog --milestone 'v1.0 release stabilization (2026-03)'
+
+# 4) 旧Milestoneをクローズ
+gh api repos/doooooraku/Repolog/milestones/<旧番号> --method PATCH -f state='closed'
+```
+
+判断基準:
+- 旧Milestoneの `open_issues` が 0 ならクローズ
+- 1件でも未完了がある場合は、翌Milestoneへ移してからクローズ
+
 ### 工程W-12：リリース（EAS/Store手順に従う）
 
 * **トリガーキー**：mainが安定 / 仕様書から作成するIssue/バグが無くなった


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
Milestoneを毎サイクルで締めるための運用手順（作成・移送・クローズ）を `whole_workflow` に追加しました。既に実運用として Milestone #1 を閉じ、Milestone #2 を作成済みです。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [ ] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [ ] test（テスト追加/修正）
- [x] docs（ドキュメント）
- [x] chore（雑務：依存更新など）
- [ ] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #65
- 参照:
  - docs/how-to/whole_workflow.md
  - https://github.com/doooooraku/Repolog/milestone/1
  - https://github.com/doooooraku/Repolog/milestone/2

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: 計画進捗の「完了」を明示し、次サイクルへ連続的に移行できるようにする
- 背景: Milestoneのクローズタイミングが明文化されておらず、運用の属人化リスクがあった

---

## 3. 変更点（What / REQUIRED）
- `W-11.5` に Milestone締め処理（確認→次Milestone作成→Issue移送→旧Milestoneクローズ）を追加
- 実運用として以下を実施
  - `v1.0 release stabilization (2026-03)` を作成
  - Open Issueを新Milestoneへ移送
  - `v1.0 hardening (2026-02)` をクローズ

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] AC1: 完了済みMilestoneをクローズ
- [x] AC2: 次Milestoneを作成
- [x] AC3: 運用手順に更新タイミングを明記

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [ ] pnpm test:e2e（結果：未実行）
- [x] pnpm type-check（結果：✅）
- CI（GitHub Actions）:
  - [ ] 全部 ✅（PR作成後確認）

### 6-2. 手動確認
1. `gh api repos/.../milestones?state=all` で #1 が closed、#2 が open であること
2. Open Issueが #2 に割り当て済みであること
3. `docs/how-to/whole_workflow.md` にコマンド手順があること

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] 運用手順が変わる → docs/how-to/whole_workflow.md を更新

---

## 9. リスク評価 & ロールバック（REQUIRED）
- 想定リスク: Milestoneを早く閉じすぎる運用ミス
- 検知方法: open_issues件数をAPIで確認
- 影響の大きさ: 低
- ロールバック: Milestoneを再openしIssueを戻す
