### PR TITLE
ops: pin CI actions and document SHA pin governance (#71)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,13 +15,13 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
-        uses: actions/checkout@v4
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
       - name: Setup pnpm
-        uses: pnpm/action-setup@v4
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
         with:
           version: "10"
       - name: Setup Node
-        uses: actions/setup-node@v4
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
         with:
           node-version: "20"
           cache: "pnpm"

--- a/docs/how-to/whole_workflow.md
+++ b/docs/how-to/whole_workflow.md
@@ -176,6 +176,11 @@ Repolog を **「仕様→Issue→実装→テスト→PR→マージ→リリ�
   - `enforce_admins.enabled` が `true`
   - `allow_force_pushes.enabled` が `false`
   - `allow_deletions.enabled` が `false`
+* **供給網チェック（GitHub Actions）**：
+  `gh api repos/doooooraku/Repolog/actions/permissions`
+  - `sha_pinning_required` が `true`（full-length SHA固定を強制）
+  - `allowed_actions` が運用方針に一致（`all` か `selected`）
+  - `.github/workflows/*.yml` の `uses:` が `@<40桁SHA>` で固定されている
 * **担当**：Codex
 
 #### W-10 補足：承認レビューを満たす運用（Repolog）
@@ -192,6 +197,22 @@ gh pr review <PR番号> --approve --body "Reviewed and approved."
 
 # 作業者アカウントへ戻す
 gh auth switch -u doooooraku
+```
+
+#### W-10 補足：Actions SHA固定ポリシー確認（Repolog）
+
+```bash
+# 現在のActionsポリシー確認
+gh api repos/doooooraku/Repolog/actions/permissions
+
+# 例: SHA固定を必須化する（管理者のみ）
+gh api repos/doooooraku/Repolog/actions/permissions --method PUT \
+  -f enabled=true \
+  -f allowed_actions=all \
+  -f sha_pinning_required=true
+
+# workflow内の uses: を確認
+rg -n \"uses:\" .github/workflows
 ```
 
 ### 工程W-11：マージ（mainに反映）


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
CI workflow の Action 参照を commit SHA 固定に変更し、供給網リスクを低減しました。あわせて `docs/how-to/whole_workflow.md` に SHA pin 運用手順を追記しました。

---

## 0. 種別（REQUIRED）
- [x] docs（ドキュメント）
- [x] chore（雑務：依存更新など）

---

## 1. 関連リンク（REQUIRED）
- Issue: #71
- ADR: なし
- 参照:
  - constraints: docs/reference/constraints.md
  - workflow: docs/how-to/whole_workflow.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: CI基盤の安全性を高め、意図しないAction更新による事故を減らす
- バグの再現条件（バグなら）: N/A

---

## 3. 変更点（What / REQUIRED）
- `.github/workflows/ci.yml` の `uses:` を full-length commit SHA pin に変更
  - `actions/checkout`
  - `pnpm/action-setup`
  - `actions/setup-node`
- `docs/how-to/whole_workflow.md` に以下を追記
  - `gh api repos/.../actions/permissions` によるポリシー確認
  - `sha_pinning_required` の運用確認手順
  - リポジトリ管理者向け `PUT` 設定例
- リポジトリ設定を更新（管理API）
  - `sha_pinning_required: true`

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] 条件1：`ci.yml` の第三者Actionが commit SHA pin されている
- [x] 条件2：`actions/permissions` で `sha_pinning_required=true` を確認
- [x] 条件3：運用手順が docs に明記されている

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面（UI）: なし
- 機能: CI運用
- 影響する層:
  - [x] Free
  - [x] Pro

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし
- 移行（migration）が必要:
  - [x] なし

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [x] なし
- 端末/OS差分の懸念:
  - [x] なし

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [x] pnpm type-check（結果：✅）
- CI（GitHub Actions）:
  - [ ] 全部 ✅（本PRで確認予定）

### 6-2. 手動確認
1. `gh api repos/doooooraku/Repolog/actions/permissions`
2. `rg -n "uses:" .github/workflows/ci.yml`
3. `gh api repos/doooooraku/Repolog/branches/main/protection`
- 期待結果: `sha_pinning_required=true` かつ workflow 内ActionがSHA固定
- 実際結果: 確認済み（CIはPRで最終確認）

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] 運用手順が変わる → `docs/how-to/whole_workflow.md` を更新
- [x] どれも不要ではない（運用変更あり）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク
- 想定リスク: 将来のAction更新時にSHA更新漏れでCI失敗
- 検知方法: CI失敗ログ、`actions/permissions` 設定確認
- 影響の大きさ:
  - [x] 低（CI運用の手間増）

### 9-2. ロールバック
- 戻し方（最短手順）: 本PRをrevertし、必要なら `sha_pinning_required=false` に戻す
- 影響範囲の切り分け: CIワークフローのみ

---

## 10. セキュリティ / 課金 / 広告
- [x] Secrets/キー直書きなし
- [x] 個人情報ログ出力なし
- [x] 外部GitHub Actionsの追加/更新がある → commit SHA pin 済み

---

## 12. PRサイズ
- [x] 小（〜200行）

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲（UI/機能/データ/Free/Pro）を書いた
- [x] 合否が判定できる動作確認を記載した（自動/手動）
- [ ] CIが通った（確認中）
- [x] docs影響を判定し、必要なら更新した
- [x] リスクとロールバックを書いた
