### PR TITLE
docs: add backup import/export runbook and troubleshooting (#74)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -30,6 +30,7 @@
   - Issue -> PR -> CI -> Release の「やり方」
   - 例：`docs/how-to/legal_pages_github_pages.md`（法務ページ公開とリンク運用）
   - 例：`docs/how-to/release_notes_template.md`（タグ命名規則とReleaseノート雛形）
+  - 例：`docs/how-to/backup_restore.md`（バックアップ復元と障害切り分け）
 
 ---
 

--- a/docs/how-to/backup_restore.md
+++ b/docs/how-to/backup_restore.md
@@ -1,0 +1,188 @@
+# Backup Import/Export Runbook（Repolog）
+最終更新: 2026-02-10（JST）
+
+この文書は **How-to（やり方）** です。  
+実装の正は `src/features/backup/backupService.ts` と `__tests__/backupImportPlanner.test.ts` を参照してください。
+
+---
+
+## 0. この文書の目的
+- バックアップの Export / Import を、第三者が同じ手順で再現できるようにする
+- 障害時に「どこで失敗しているか」を切り分ける
+- append（追加）戦略の前提を運用側にも固定する
+
+---
+
+## 1. まず固定する前提（Source of Truth）
+- バックアップ形式:
+  - `manifest.json`
+  - `photos/`（画像ファイル）
+- スキーマ互換:
+  - 現在は `schemaVersion = 1`
+- Import戦略:
+  - **append（追加）**
+  - 既存データは削除しない
+  - `report.id` / `photo.id` が重複したらスキップ
+  - 同じバックアップを再Importしても重複登録しない（冪等）
+
+関連:
+- `docs/adr/ADR-0007-backup-import-append-strategy.md`
+- `src/features/backup/backupService.ts`
+- `__tests__/backupImportPlanner.test.ts`
+
+---
+
+## 2. 事前準備（ユーザー/運用者共通）
+1. 端末に十分な空き容量があることを確認する
+2. Export時:
+   - 共有シートが使える端末であることを確認する
+3. Import時:
+   - `.zip` ファイルを端末から選べる状態にする
+
+注意:
+- Web ではバックアップ機能は未対応（`unsupported`）
+- PDFファイルはバックアップ対象外
+
+---
+
+## 3. Export手順（標準運用）
+1. アプリで Settings を開く
+2. `Backup` を開く
+3. `Export` を押す
+4. 共有シートで保存先を選ぶ（Files / Drive 等）
+5. `repolog-backup-<timestamp>.zip` が出力されたことを確認する
+
+期待結果:
+- zip内に `manifest.json` と `photos/` が存在する
+- エラー時は次のいずれか:
+  - `Sharing unavailable`
+  - `Failed to export backup`
+
+---
+
+## 4. Import手順（append運用）
+1. アプリで Settings を開く
+2. `Backup` を開く
+3. `Import` を押す
+4. zipファイルを選択する
+5. Import完了メッセージを確認する
+   - 例: `Added {reports} reports and {photos} photos.`
+
+期待結果:
+- 既存レポート/写真は保持される（削除されない）
+- 重複IDはスキップされる
+- 新規分だけ追加される
+
+---
+
+## 5. トラブルシューティング（切り分け表）
+
+### 5.1 `Invalid backup` が出る
+想定原因:
+- zip内に `manifest.json` がない
+- `photos/` がない
+- `manifest.json` のJSONが壊れている
+- `photos` が存在しない `reportId` を参照している
+- zip内で参照された写真ファイルが実体として存在しない
+
+確認ポイント:
+1. zipを展開して `manifest.json` と `photos/` の存在を確認
+2. `manifest.json` がJSONとして読めるか確認
+3. `manifest.photos[].reportId` が `manifest.reports[].id` に存在するか確認
+
+対処:
+- 正常なバックアップを再取得する
+- 壊れたzipは再利用しない
+
+### 5.2 `Unsupported backup` が出る
+想定原因:
+- `schemaVersion` が現行アプリと不一致
+
+確認ポイント:
+1. `manifest.json` の `schemaVersion` を確認
+
+対処:
+- 同じメジャー系統のアプリバージョンで再実行
+- 互換方針が必要な場合はADRを起票
+
+### 5.3 `Not supported` が出る
+想定原因:
+- Web環境など非対応プラットフォーム
+
+対処:
+- iOS/Android端末で実行する
+
+### 5.4 `Sharing unavailable` が出る（Export）
+想定原因:
+- 共有シートを開けない端末/設定
+
+対処:
+- 共有機能が有効な端末で再実行
+
+### 5.5 追加件数が `0`（Import成功だが増えない）
+想定原因:
+- Importしたバックアップがすべて既存IDと重複している
+
+対処:
+- これはappend戦略上の正常動作
+- 重複スキップ件数の可視化改善が必要ならIssue化する
+
+---
+
+## 6. 受け入れ条件に対応した確認手順（Issue #74）
+
+### AC1: 手順書だけで復元を再現できる
+1. 端末AでExport zipを作成
+2. 端末B（または同端末の別データ状態）でImport
+3. レポート/写真が追加されることを確認
+
+### AC2: 失敗時の切り分け
+以下を意図的に作って挙動確認:
+1. `manifest.json` なしzip → `Invalid backup`
+2. `schemaVersion` 改変zip → `Unsupported backup`
+3. 重複IDのみzip → 成功 + 追加0件
+
+### AC3: 導線リンク
+- 本文書から:
+  - `docs/how-to/testing.md`
+  - `docs/how-to/whole_workflow.md`
+- 逆リンク:
+  - `docs/how-to/testing.md` から本Runbook
+  - `docs/how-to/whole_workflow.md` から本Runbook
+
+---
+
+## 7. 開発者向け検証コマンド
+
+### 7.1 append判定ロジックだけを確認
+```bash
+pnpm test __tests__/backupImportPlanner.test.ts
+```
+意味:
+- バックアップImportの追加/スキップ判定を単体で検証する
+
+### 7.2 PR前の最低ライン
+```bash
+pnpm install --frozen-lockfile
+pnpm lint
+pnpm test
+```
+意味:
+- CIと同じ順序で依存解決・静的検査・テストを行う
+
+---
+
+## 8. 運用インシデント対応（簡易）
+1. 症状を記録（日時 / 端末 / zip元 / エラー文言）
+2. `Invalid` / `Schema` / `Unsupported` / `Share` のどれかに分類
+3. 再現手順をIssueへ転記
+4. 必要なら zip（個人情報に注意）を安全経路で回収し検証
+
+---
+
+## 9. 参照リンク（一次情報）
+- Expo DocumentPicker: https://docs.expo.dev/versions/latest/sdk/document-picker/
+- Expo FileSystem: https://docs.expo.dev/versions/latest/sdk/filesystem/
+- Expo Sharing: https://docs.expo.dev/versions/latest/sdk/sharing/
+- react-native-zip-archive: https://github.com/mockingbot/react-native-zip-archive
+

--- a/docs/how-to/testing.md
+++ b/docs/how-to/testing.md
@@ -14,6 +14,7 @@
 - PRを出す前（最低限ここに書いてあるテストを通す）
 - CIが落ちたとき（どこを見て、どう再現するか）
 - 受け入れ条件を「実行できる仕様」に寄せたいとき（テストを追加したいとき）
+- バックアップImport/Export障害を切り分けるとき（`docs/how-to/backup_restore.md`）
 
 ---
 
@@ -274,6 +275,23 @@ CIが落ちたステップだけを、まずローカルで叩く：
   - Import append時の「追加/スキップ」判定
   - 不正な `reportId` 参照を含む写真の検知
   - 同一バックアップ再Import時の冪等性（重複しない）
+
+### 7.2 バックアップ運用の確認（#74）
+
+- 運用手順の正: `docs/how-to/backup_restore.md`
+- append戦略の正: `docs/adr/ADR-0007-backup-import-append-strategy.md`
+- 実装の正: `src/features/backup/backupService.ts`
+
+最小コマンド:
+
+```bash
+pnpm test __tests__/backupImportPlanner.test.ts
+```
+
+確認観点:
+- 既存データを削除しない
+- 重複IDをスキップする
+- 同一zip再Importで重複登録しない
 
 ---
 

--- a/docs/how-to/whole_workflow.md
+++ b/docs/how-to/whole_workflow.md
@@ -18,6 +18,7 @@
   * `docs/how-to/whole_workflow.md`（開発〜リリースの回し方）
   * `docs/how-to/git_workflow.md`（Issue~mergeの回し方）
   * `docs/how-to/testing.md`（テストの回し方。正はCI/package.jsonにリンク）
+  * `docs/how-to/backup_restore.md`（バックアップImport/Exportの運用と障害切り分け）
   * `docs/how-to/android_ビルド手順.md`（Androidビルド手順）
   * `docs/how-to/ios_ビルド手順.md`（iOSビルド手順）
   * `docs/how-to/legal_pages_github_pages.md`（法務ページ公開と運用）
@@ -229,6 +230,7 @@ rg -n \"uses:\" .github/workflows
 * **トリガーキー**：W-11 完了
 * **作業内容**：
   * 仕様書（product_strategy / constraints / *spec）をざっと読み直す
+  * 運用Runbook（testing / backup_restore / release）を読み直す
   * 「まだIssue化されていない作業」があれば Issue を追加する
 * **INPUT**：mainの最新仕様書
 * **OUTPUT**：追加Issue（必要な場合）


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
バックアップ Import/Export の運用Runbookを追加し、障害切り分け手順を明文化しました。  
`testing.md` / `whole_workflow.md` / `docs/README.md` から導線を追加し、Issue #74 のACを満たす構成にしています。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [ ] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [ ] test（テスト追加/修正）
- [x] docs（ドキュメント）
- [ ] chore（雑務：依存更新など）
- [ ] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #74
- ADR: docs/adr/ADR-0007-backup-import-append-strategy.md
- 参照（1つ以上推奨）:
  - constraints: docs/reference/constraints.md
  - workflow: docs/how-to/whole_workflow.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: バックアップ障害時に再現可能な手順で復旧できる
- バグの再現条件（バグなら）: 該当なし

---

## 3. 変更点（What / REQUIRED）
- `docs/how-to/backup_restore.md` を新規追加
- Export/Importの標準手順、append戦略、失敗時切り分けを整理
- `docs/how-to/testing.md` にバックアップ確認導線を追加
- `docs/how-to/whole_workflow.md` と `docs/README.md` にRunbookリンク追加

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] AC1: 手順書だけで復元を再現できる
- [x] AC2: Import失敗時の切り分け手順（zip破損/スキーマ違い/重複）が明記される
- [x] AC3: whole_workflow/testing から該当手順へのリンクがある

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面（UI）: なし
- 機能: バックアップ運用ドキュメント
- 影響する層:
  - [x] Free
  - [x] Pro
  - [ ] 両方

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし
  - [ ] あり（内容：　　　　　　　　　）
- 移行（migration）が必要:
  - [x] なし
  - [ ] あり（手順/ロールバック：　　　　　　　　　）

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [x] なし
  - [ ] あり（対象言語：　　　　　　）
- 端末/OS差分の懸念:
  - [x] なし
  - [ ] あり（内容：　　　　　　　　　）

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト（該当を残す / RECOMMENDED）
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [ ] pnpm test:e2e（結果：未実施 / docs変更のみ）
- [x] pnpm type-check（結果：✅）
- CI（GitHub Actions）:
  - [ ] 全部 ✅
  - [x] 一部 ❌（理由：PR作成直後のため未確認）

### 6-2. 手動確認（手順を箇条書き / REQUIRED）
1. `docs/how-to/backup_restore.md` を開く
2. AC1/AC2/AC3の記述有無を確認
3. `docs/how-to/testing.md` と `docs/how-to/whole_workflow.md` に逆リンクがあることを確認
- 期待結果: 3つのACに対応する記載が揃っている
- 実際結果: 期待通り

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [ ] 仕様/前提/制約が変わる → docs/reference/constraints.md を更新（リンク：）
- [ ] 用語が増える/意味が変わる → docs/reference/glossary.md を更新（リンク：）
- [x] 運用手順が変わる → docs/how-to/whole_workflow.md を更新（リンク：docs/how-to/whole_workflow.md）
- [ ] リリース手順に影響 → docs/how-to/android_ビルド手順.md / docs/how-to/ios_ビルド手順.md を更新（リンク：）
- [ ] 意思決定が増えた/変わった → docs/adr/ADR-XXXX.md を追加 or 更新（リンク：）
- [ ] テスト観点が変わる → テスト（Jest/Maestro）を追加/更新（リンク or 該当ファイル：）
- [ ] どれも不要（理由：外部仕様/運用/テスト観点に影響なし、内部リファクタのみ）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク（短く）
- 想定リスク: 実装変更時にRunbookが古くなる
- 検知方法（どうやって気づく？）: バックアップ障害時の再現不能、PRレビュー
- 影響の大きさ:
  - [x] 低（困るが致命傷ではない）
  - [ ] 中（ユーザーの一部が詰まる）
  - [ ] 高（課金/データ消失/起動不可など）

### 9-2. ロールバック（戻し方 / REQUIRED）
- 戻し方（最短手順）: このPRを revert
- 影響範囲の切り分け（できれば）: docs/how-to配下のみ

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲（UI/機能/データ/Free/Pro）を書いた
- [x] “合否が判定できる” 動作確認を記載した（自動/手動）
- [x] CIが通った（または通せない理由を明記）
- [x] docs影響を判定し、必要なら更新した（links記載）
- [x] リスクとロールバックを書いた

Closes #74
