### PR TITLE
fix: stabilize settings navigation in Maestro smoke (#77)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -12,6 +12,7 @@ import {
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { Image } from 'expo-image';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { AdBanner } from '@/components/ad-banner';
 import { IconSymbol } from '@/components/ui/icon-symbol';
@@ -211,129 +212,135 @@ export default function HomeScreen() {
   }
 
   return (
-    <View style={styles.container} testID="e2e_home_screen">
-      <View style={styles.headerRow}>
-        <Text style={styles.title}>{t.homeTitle}</Text>
-        <View style={styles.headerActions}>
-          <Pressable
-            testID="e2e_home_create_report_fab"
-            onPress={() => router.push('/reports/new')}
-            hitSlop={12}
-            style={styles.iconButton}>
-            <IconSymbol name="plus" size={20} color="#111" />
-          </Pressable>
-          <Pressable
-            testID="e2e_open_settings"
-            onPress={() => router.push('/settings')}
-            hitSlop={12}
-            style={styles.iconButton}>
-            <IconSymbol name="gearshape.fill" size={20} color="#111" />
-          </Pressable>
-        </View>
-      </View>
-      <TextInput
-        placeholder={t.homeSearchPlaceholder}
-        value={query}
-        onChangeText={setQuery}
-        style={styles.search}
-      />
-      <View style={styles.filterPanel}>
-        <Text style={styles.filterTitle}>{t.homeFiltersTitle}</Text>
-        <View style={styles.filterRow}>
-          <View style={styles.filterColumn}>
-            <Text style={styles.filterLabel}>{t.homeFilterFromLabel}</Text>
-            <TextInput
-              testID="e2e_home_filter_from"
-              value={fromDate}
-              onChangeText={setFromDate}
-              placeholder={t.homeFilterDatePlaceholder}
-              style={styles.filterInput}
-            />
-          </View>
-          <View style={styles.filterColumn}>
-            <Text style={styles.filterLabel}>{t.homeFilterToLabel}</Text>
-            <TextInput
-              testID="e2e_home_filter_to"
-              value={toDate}
-              onChangeText={setToDate}
-              placeholder={t.homeFilterDatePlaceholder}
-              style={styles.filterInput}
-            />
+    <SafeAreaView style={styles.safeArea} edges={['top']}>
+      <View style={styles.container} testID="e2e_home_screen">
+        <View style={styles.headerRow}>
+          <Text style={styles.title}>{t.homeTitle}</Text>
+          <View style={styles.headerActions}>
+            <Pressable
+              testID="e2e_home_create_report_fab"
+              onPress={() => router.push('/reports/new')}
+              hitSlop={12}
+              style={styles.iconButton}>
+              <IconSymbol name="plus" size={20} color="#111" />
+            </Pressable>
+            <Pressable
+              testID="e2e_open_settings"
+              onPress={() => router.push('/settings')}
+              hitSlop={12}
+              style={styles.iconButton}>
+              <IconSymbol name="gearshape.fill" size={20} color="#111" />
+            </Pressable>
           </View>
         </View>
-        <View style={styles.filterTagInputRow}>
-          <TextInput
-            testID="e2e_home_filter_tags_input"
-            value={filterTagInput}
-            onChangeText={setFilterTagInput}
-            onSubmitEditing={handleAddFilterTags}
-            placeholder={t.homeFilterTagPlaceholder}
-            style={[styles.filterInput, styles.filterTagInput]}
-            returnKeyType="done"
-          />
-          <Pressable
-            testID="e2e_home_filter_tags_add"
-            onPress={handleAddFilterTags}
-            style={styles.filterTagAddButton}>
-            <Text style={styles.filterTagAddText}>{t.addTagAction}</Text>
-          </Pressable>
-        </View>
-        {filterTags.length > 0 && (
-          <View style={styles.filterTagsWrap}>
-            {filterTags.map((tag) => (
-              <Pressable
-                key={tag}
-                testID={`e2e_home_filter_tag_${sanitizeTestIdToken(tag)}`}
-                onPress={() => handleRemoveFilterTag(tag)}
-                style={styles.filterTagChip}>
-                <Text style={styles.filterTagChipText}>{tag}</Text>
-                <Text style={styles.filterTagChipRemove}>×</Text>
-              </Pressable>
-            ))}
-          </View>
-        )}
-        <View style={styles.filterSwitchRow}>
-          <Text style={styles.filterLabel}>{t.homeFilterPinnedOnlyLabel}</Text>
-          <Switch testID="e2e_home_filter_pinned_only" value={pinnedOnly} onValueChange={setPinnedOnly} />
-        </View>
-        {hasActiveFilters && (
-          <Pressable
-            testID="e2e_home_filter_reset"
-            onPress={handleResetFilters}
-            style={styles.filterResetButton}>
-            <Text style={styles.filterResetText}>{t.homeFilterResetAction}</Text>
-          </Pressable>
-        )}
-      </View>
-      {sections.length === 0 ? (
-        <View style={styles.empty}>
-          <Text style={styles.emptyTitle}>{t.homeEmptyTitle}</Text>
-          <Text style={styles.emptyBody}>{t.homeEmptyBody}</Text>
-          <Pressable
-            testID="e2e_home_create_report"
-            style={styles.newButton}
-            onPress={() => router.push('/reports/new')}>
-            <Text style={styles.newButtonText}>{t.homeCreateReport}</Text>
-          </Pressable>
-        </View>
-      ) : (
-        <SectionList
-          sections={sections}
-          keyExtractor={(item) => item.id}
-          renderItem={renderItem}
-          renderSectionHeader={({ section }) => (
-            <Text style={styles.sectionHeader}>{section.title}</Text>
-          )}
-          contentContainerStyle={styles.listContent}
-          style={styles.list}
+        <TextInput
+          placeholder={t.homeSearchPlaceholder}
+          value={query}
+          onChangeText={setQuery}
+          style={styles.search}
         />
-      )}
-      {proInitialized && !isPro && <AdBanner />}
-    </View>
+        <View style={styles.filterPanel}>
+          <Text style={styles.filterTitle}>{t.homeFiltersTitle}</Text>
+          <View style={styles.filterRow}>
+            <View style={styles.filterColumn}>
+              <Text style={styles.filterLabel}>{t.homeFilterFromLabel}</Text>
+              <TextInput
+                testID="e2e_home_filter_from"
+                value={fromDate}
+                onChangeText={setFromDate}
+                placeholder={t.homeFilterDatePlaceholder}
+                style={styles.filterInput}
+              />
+            </View>
+            <View style={styles.filterColumn}>
+              <Text style={styles.filterLabel}>{t.homeFilterToLabel}</Text>
+              <TextInput
+                testID="e2e_home_filter_to"
+                value={toDate}
+                onChangeText={setToDate}
+                placeholder={t.homeFilterDatePlaceholder}
+                style={styles.filterInput}
+              />
+            </View>
+          </View>
+          <View style={styles.filterTagInputRow}>
+            <TextInput
+              testID="e2e_home_filter_tags_input"
+              value={filterTagInput}
+              onChangeText={setFilterTagInput}
+              onSubmitEditing={handleAddFilterTags}
+              placeholder={t.homeFilterTagPlaceholder}
+              style={[styles.filterInput, styles.filterTagInput]}
+              returnKeyType="done"
+            />
+            <Pressable
+              testID="e2e_home_filter_tags_add"
+              onPress={handleAddFilterTags}
+              style={styles.filterTagAddButton}>
+              <Text style={styles.filterTagAddText}>{t.addTagAction}</Text>
+            </Pressable>
+          </View>
+          {filterTags.length > 0 && (
+            <View style={styles.filterTagsWrap}>
+              {filterTags.map((tag) => (
+                <Pressable
+                  key={tag}
+                  testID={`e2e_home_filter_tag_${sanitizeTestIdToken(tag)}`}
+                  onPress={() => handleRemoveFilterTag(tag)}
+                  style={styles.filterTagChip}>
+                  <Text style={styles.filterTagChipText}>{tag}</Text>
+                  <Text style={styles.filterTagChipRemove}>×</Text>
+                </Pressable>
+              ))}
+            </View>
+          )}
+          <View style={styles.filterSwitchRow}>
+            <Text style={styles.filterLabel}>{t.homeFilterPinnedOnlyLabel}</Text>
+            <Switch testID="e2e_home_filter_pinned_only" value={pinnedOnly} onValueChange={setPinnedOnly} />
+          </View>
+          {hasActiveFilters && (
+            <Pressable
+              testID="e2e_home_filter_reset"
+              onPress={handleResetFilters}
+              style={styles.filterResetButton}>
+              <Text style={styles.filterResetText}>{t.homeFilterResetAction}</Text>
+            </Pressable>
+          )}
+        </View>
+        {sections.length === 0 ? (
+          <View style={styles.empty}>
+            <Text style={styles.emptyTitle}>{t.homeEmptyTitle}</Text>
+            <Text style={styles.emptyBody}>{t.homeEmptyBody}</Text>
+            <Pressable
+              testID="e2e_home_create_report"
+              style={styles.newButton}
+              onPress={() => router.push('/reports/new')}>
+              <Text style={styles.newButtonText}>{t.homeCreateReport}</Text>
+            </Pressable>
+          </View>
+        ) : (
+          <SectionList
+            sections={sections}
+            keyExtractor={(item) => item.id}
+            renderItem={renderItem}
+            renderSectionHeader={({ section }) => (
+              <Text style={styles.sectionHeader}>{section.title}</Text>
+            )}
+            contentContainerStyle={styles.listContent}
+            style={styles.list}
+          />
+        )}
+        {proInitialized && !isPro && <AdBanner />}
+      </View>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#f6f6f6',
+  },
   container: {
     flex: 1,
     padding: 16,

--- a/maestro/flows/smoke.yml
+++ b/maestro/flows/smoke.yml
@@ -18,6 +18,8 @@ tags:
 - tapOn:
     id: "e2e_open_settings"
     label: "設定を開く"
+    retryTapIfNoChange: true
+    waitUntilVisible: true
 - extendedWaitUntil:
     visible:
       id: "e2e_settings_screen"

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -10,6 +10,7 @@ import {
   View,
 } from 'react-native';
 import { useRouter } from 'expo-router';
+import { SafeAreaView } from 'react-native-safe-area-context';
 
 import { useTranslation, type Lang, type TranslationKey } from '@/src/core/i18n/i18n';
 import { useSettingsStore } from '@/src/stores/settingsStore';
@@ -95,122 +96,128 @@ export default function SettingsScreen() {
   };
 
   return (
-    <ScrollView contentContainerStyle={styles.container} testID="e2e_settings_screen">
-      <View style={styles.headerRow}>
-        <Pressable testID="e2e_back_home" onPress={() => router.back()} style={styles.backButton}>
-          <Text style={styles.backText}>{'‹'}</Text>
-        </Pressable>
-        <Text style={styles.headerTitle}>{t.settings}</Text>
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t.settingsSectionGeneral}</Text>
-        <Text style={styles.sectionBody}>{t.languageChange}</Text>
-        <Pressable
-          testID="e2e_language_toggle"
-          onPress={() => setShowLanguages((prev) => !prev)}
-          style={styles.rowBetween}>
-          <Text
-            style={styles.valueText}
-            testID={`e2e_current_language_${toLangTestId(lang)}`}>{`${t.currentLanguage}: ${currentLanguageLabel}`}</Text>
-          <Text style={styles.chevron}>{showLanguages ? '▲' : '▼'}</Text>
-        </Pressable>
-        {showLanguages && (
-          <View style={styles.optionList}>
-            {LANGUAGE_OPTIONS.map((option) => {
-              const active = option.code === lang;
-              return (
-                <Pressable
-                  key={option.code}
-                  testID={`e2e_language_option_${toLangTestId(option.code)}`}
-                  onPress={() => setLang(option.code)}
-                  style={[styles.optionRow, active && styles.optionRowActive]}>
-                  <Text style={[styles.optionText, active && styles.optionTextActive]}>
-                    {t[option.labelKey] ?? option.code}
-                  </Text>
-                  {active && (
-                    <Text
-                      style={styles.optionCheck}
-                      testID={`e2e_language_selected_${toLangTestId(option.code)}`}>
-                      ✓
-                    </Text>
-                  )}
-                </Pressable>
-              );
-            })}
-          </View>
-        )}
-      </View>
-
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t.settingsSectionPrivacy}</Text>
-        <Text style={styles.sectionBody}>{t.includeLocationHelp}</Text>
-        <View style={styles.rowBetween}>
-          <Text style={styles.valueText}>{t.includeLocationLabel}</Text>
-          <Switch value={includeLocation} onValueChange={setIncludeLocation} />
+    <SafeAreaView style={styles.safeArea} edges={['top']}>
+      <ScrollView contentContainerStyle={styles.container} testID="e2e_settings_screen">
+        <View style={styles.headerRow}>
+          <Pressable testID="e2e_back_home" onPress={() => router.back()} style={styles.backButton}>
+            <Text style={styles.backText}>{'‹'}</Text>
+          </Pressable>
+          <Text style={styles.headerTitle}>{t.settings}</Text>
         </View>
-        <Text style={styles.sectionBody}>{t.adPrivacyOptionsHelp}</Text>
-        <Pressable
-          testID="e2e_open_ad_privacy_options"
-          onPress={() => {
-            void handleOpenAdPrivacyOptions();
-          }}
-          style={[styles.secondaryButton, openingAdPrivacyOptions && styles.disabledButton]}
-          disabled={openingAdPrivacyOptions}>
-          {openingAdPrivacyOptions ? (
-            <ActivityIndicator />
-          ) : (
-            <Text style={styles.secondaryButtonText}>{t.adPrivacyOptionsAction}</Text>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t.settingsSectionGeneral}</Text>
+          <Text style={styles.sectionBody}>{t.languageChange}</Text>
+          <Pressable
+            testID="e2e_language_toggle"
+            onPress={() => setShowLanguages((prev) => !prev)}
+            style={styles.rowBetween}>
+            <Text
+              style={styles.valueText}
+              testID={`e2e_current_language_${toLangTestId(lang)}`}>{`${t.currentLanguage}: ${currentLanguageLabel}`}</Text>
+            <Text style={styles.chevron}>{showLanguages ? '▲' : '▼'}</Text>
+          </Pressable>
+          {showLanguages && (
+            <View style={styles.optionList}>
+              {LANGUAGE_OPTIONS.map((option) => {
+                const active = option.code === lang;
+                return (
+                  <Pressable
+                    key={option.code}
+                    testID={`e2e_language_option_${toLangTestId(option.code)}`}
+                    onPress={() => setLang(option.code)}
+                    style={[styles.optionRow, active && styles.optionRowActive]}>
+                    <Text style={[styles.optionText, active && styles.optionTextActive]}>
+                      {t[option.labelKey] ?? option.code}
+                    </Text>
+                    {active && (
+                      <Text
+                        style={styles.optionCheck}
+                        testID={`e2e_language_selected_${toLangTestId(option.code)}`}>
+                        ✓
+                      </Text>
+                    )}
+                  </Pressable>
+                );
+              })}
+            </View>
           )}
-        </Pressable>
-      </View>
+        </View>
 
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t.settingsSectionPurchases}</Text>
-        <Text style={styles.sectionBody}>{t.restoreDesc}</Text>
-        <Pressable
-          onPress={handleRestore}
-          style={[styles.primaryButton, restoring && styles.disabledButton]}
-          disabled={restoring}>
-          {restoring ? (
-            <ActivityIndicator color="#fff" />
-          ) : (
-            <Text style={styles.primaryButtonText}>{t.restore}</Text>
-          )}
-        </Pressable>
-      </View>
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t.settingsSectionPrivacy}</Text>
+          <Text style={styles.sectionBody}>{t.includeLocationHelp}</Text>
+          <View style={styles.rowBetween}>
+            <Text style={styles.valueText}>{t.includeLocationLabel}</Text>
+            <Switch value={includeLocation} onValueChange={setIncludeLocation} />
+          </View>
+          <Text style={styles.sectionBody}>{t.adPrivacyOptionsHelp}</Text>
+          <Pressable
+            testID="e2e_open_ad_privacy_options"
+            onPress={() => {
+              void handleOpenAdPrivacyOptions();
+            }}
+            style={[styles.secondaryButton, openingAdPrivacyOptions && styles.disabledButton]}
+            disabled={openingAdPrivacyOptions}>
+            {openingAdPrivacyOptions ? (
+              <ActivityIndicator />
+            ) : (
+              <Text style={styles.secondaryButtonText}>{t.adPrivacyOptionsAction}</Text>
+            )}
+          </Pressable>
+        </View>
 
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t.settingsSectionBackup}</Text>
-        <Text style={styles.sectionBody}>{t.settingsBackupDesc}</Text>
-        <Pressable onPress={() => router.push('/backup')} style={styles.secondaryButton}>
-          <Text style={styles.secondaryButtonText}>{t.settingsBackupOpen}</Text>
-        </Pressable>
-      </View>
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t.settingsSectionPurchases}</Text>
+          <Text style={styles.sectionBody}>{t.restoreDesc}</Text>
+          <Pressable
+            onPress={handleRestore}
+            style={[styles.primaryButton, restoring && styles.disabledButton]}
+            disabled={restoring}>
+            {restoring ? (
+              <ActivityIndicator color="#fff" />
+            ) : (
+              <Text style={styles.primaryButtonText}>{t.restore}</Text>
+            )}
+          </Pressable>
+        </View>
 
-      <View style={styles.section}>
-        <Text style={styles.sectionTitle}>{t.legalSectionTitle}</Text>
-        <Text style={styles.sectionBody}>{t.settingsLegalDesc}</Text>
-        <Pressable
-          onPress={() => {
-            void handleOpenLegal(legalLinks.privacyUrl);
-          }}
-          style={styles.secondaryButton}>
-          <Text style={styles.secondaryButtonText}>{t.legalPrivacyPolicyLabel}</Text>
-        </Pressable>
-        <Pressable
-          onPress={() => {
-            void handleOpenLegal(legalLinks.termsUrl);
-          }}
-          style={styles.secondaryButton}>
-          <Text style={styles.secondaryButtonText}>{t.legalTermsOfUseLabel}</Text>
-        </Pressable>
-      </View>
-    </ScrollView>
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t.settingsSectionBackup}</Text>
+          <Text style={styles.sectionBody}>{t.settingsBackupDesc}</Text>
+          <Pressable onPress={() => router.push('/backup')} style={styles.secondaryButton}>
+            <Text style={styles.secondaryButtonText}>{t.settingsBackupOpen}</Text>
+          </Pressable>
+        </View>
+
+        <View style={styles.section}>
+          <Text style={styles.sectionTitle}>{t.legalSectionTitle}</Text>
+          <Text style={styles.sectionBody}>{t.settingsLegalDesc}</Text>
+          <Pressable
+            onPress={() => {
+              void handleOpenLegal(legalLinks.privacyUrl);
+            }}
+            style={styles.secondaryButton}>
+            <Text style={styles.secondaryButtonText}>{t.legalPrivacyPolicyLabel}</Text>
+          </Pressable>
+          <Pressable
+            onPress={() => {
+              void handleOpenLegal(legalLinks.termsUrl);
+            }}
+            style={styles.secondaryButton}>
+            <Text style={styles.secondaryButtonText}>{t.legalTermsOfUseLabel}</Text>
+          </Pressable>
+        </View>
+      </ScrollView>
+    </SafeAreaView>
   );
 }
 
 const styles = StyleSheet.create({
+  safeArea: {
+    flex: 1,
+    backgroundColor: '#f6f6f6',
+  },
   container: {
     padding: 16,
     paddingBottom: 40,


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
Maestro Smoke で `e2e_open_settings` タップ後に `e2e_settings_screen` が表示されず失敗する不安定性を修正しました。Home/Settings をセーフエリア対応し、smokeフローのタップを再試行可能にして E2E の再現性を上げます。

---

## 0. 種別（REQUIRED）
- [x] fix（バグ修正）
- [ ] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [ ] test（テスト追加/修正）
- [ ] docs（ドキュメント）
- [ ] chore（雑務：依存更新など）
- [ ] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #77
- ADR: なし
- 参照:
  - constraints: docs/reference/constraints.md
  - functional_spec: docs/reference/functional_spec.md
  - workflow: docs/how-to/whole_workflow.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: CIのスモークE2Eを安定させ、mainへの統合品質を継続監視できる状態にする。
- バグの再現条件（バグなら）:
  - Maestro run `21851619751` で `Assertion is false: id: e2e_settings_screen is visible` が連続発生。
  - 失敗時スクリーンショットでは Home ヘッダーがステータスバーと重なっており、設定ボタン押下が不安定。

---

## 3. 変更点（What / REQUIRED）
- `app/(tabs)/index.tsx`
  - Homeを `SafeAreaView(edges=['top'])` でラップし、ヘッダー操作をステータスバー干渉領域から外した。
- `src/features/settings/SettingsScreen.tsx`
  - Settingsも `SafeAreaView(edges=['top'])` でラップし、上部操作UIの安全領域を統一した。
- `maestro/flows/smoke.yml`
  - `e2e_open_settings` タップに `retryTapIfNoChange: true` と `waitUntilVisible: true` を追加。

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] 条件1: Home/Settingsの上部操作がステータスバーに重ならない
- [x] 条件2: smokeフローが「設定遷移タップの揺らぎ」に対して再試行可能になっている

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面（UI）: S-01 Home / S-07 Settings
- 機能: F-03 Home / テスト自動化（Maestro smoke）
- 影響する層:
  - [x] Free
  - [x] Pro
  - [ ] 両方

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし
  - [ ] あり
- 移行（migration）が必要:
  - [x] なし
  - [ ] あり

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [x] なし
  - [ ] あり
- 端末/OS差分の懸念:
  - [ ] なし
  - [x] あり（Androidで特に効果、iOSはセーフエリア準拠でUI整合）

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [ ] pnpm test:e2e（結果：未実施。CI workflow_dispatchで実行）
- [x] pnpm type-check（結果：✅）
- CI（GitHub Actions）:
  - [ ] 全部 ✅（PR作成後に確認）

### 6-2. 手動確認
1. Homeを開く
2. 右上の設定アイコンをタップ
3. Settings画面が表示されることを確認
- 期待結果: ステータスバー干渉なく遷移し、`e2e_settings_screen` が検出可能
- 実際結果: ローカルコード上は要件を満たす

### 6-3. 再現手順（バグ修正なら）
- Before: run `21851619751` で2回連続 `e2e_settings_screen` 検出失敗
- After: 本PRで再実行し、Maestro smokeの完走可否を確認予定

---

## 7. UI差分（UI変更がある場合 / REQUIRED if UI）
- Before: Home/Settings上部がステータスバー領域に近接
- After : Home/Settings上部をSafeAreaでオフセット
- Figma: なし（安全領域調整）

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] どれも不要（理由：外部仕様ではなく、既存仕様範囲内のUI安定化とE2E実行安定化）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク
- 想定リスク: 端末によって上余白が増える見た目差分
- 検知方法: PRスクリーンショット確認、Maestro smoke実行
- 影響の大きさ:
  - [x] 低
  - [ ] 中
  - [ ] 高

### 9-2. ロールバック
- 戻し方: 本PRをrevert
- 影響範囲の切り分け: Home/Settings上部レイアウト + smokeフローのみ

---

## 10. セキュリティ / 課金 / 広告
- [x] Secrets/キーを直書きしていない
- [x] 個人情報をログ出力していない
- [x] 通信はHTTPS前提で問題ない
- [ ] 課金（RevenueCat）の影響あり
- [ ] 広告（AdMob）の影響あり
- [ ] 外部GitHub Actionsの追加/更新あり

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲（UI/機能/データ/Free/Pro）を書いた
- [x] “合否が判定できる” 動作確認を記載した（自動/手動）
- [ ] CIが通った（または通せない理由を明記）
- [x] docs影響を判定し、必要なら更新した
- [x] リスクとロールバックを書いた
