### PR TITLE
feat(ad): add repeatable UMP EEA validation workflow and runbook (#93)

### DIFF
--- a/.github/workflows/ump-consent-validation.yml
+++ b/.github/workflows/ump-consent-validation.yml
@@ -1,0 +1,95 @@
+name: UMP Consent Validation
+
+on:
+  workflow_dispatch:
+    inputs:
+      platform:
+        description: "Target platform for validation checklist"
+        required: true
+        type: choice
+        default: android
+        options:
+          - android
+          - ios
+      debug_geography:
+        description: "Expected UMP debug geography"
+        required: true
+        type: choice
+        default: EEA
+        options:
+          - EEA
+          - NOT_EEA
+          - DISABLED
+          - REGULATED_US_STATE
+          - OTHER
+      test_device_ids:
+        description: "Comma-separated UMP test device IDs"
+        required: true
+        type: string
+      notes:
+        description: "Optional notes for this run"
+        required: false
+        type: string
+
+permissions:
+  contents: read
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    env:
+      TARGET_PLATFORM: ${{ inputs.platform }}
+      TARGET_DEBUG_GEOGRAPHY: ${{ inputs.debug_geography }}
+      TARGET_TEST_DEVICE_IDS: ${{ inputs.test_device_ids }}
+      TARGET_NOTES: ${{ inputs.notes }}
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup Node
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+
+      - name: Generate UMP validation checklist
+        run: |
+          mkdir -p ump-artifacts
+          node scripts/ump-consent-check.mjs \
+            --platform "$TARGET_PLATFORM" \
+            --debug-geography "$TARGET_DEBUG_GEOGRAPHY" \
+            --test-device-ids "$TARGET_TEST_DEVICE_IDS" \
+            --notes "$TARGET_NOTES" \
+            --out ump-artifacts/ump-consent-checklist.md \
+            --json > ump-artifacts/ump-consent-checklist.json
+
+      - name: Publish summary
+        run: |
+          node -e '
+          const fs = require("node:fs");
+          const report = JSON.parse(fs.readFileSync("ump-artifacts/ump-consent-checklist.json", "utf8"));
+          const lines = [
+            "## UMP validation summary",
+            "",
+            `- platform: ${report.platform}`,
+            `- debugGeography: ${report.debugGeography}`,
+            `- testDeviceIdsCount: ${report.testDeviceIds.length}`,
+            `- passed: ${report.passed ? "yes" : "no"}`,
+            "",
+            "### Failed checks",
+          ];
+          if (report.failedChecks.length === 0) {
+            lines.push("- none");
+          } else {
+            for (const check of report.failedChecks) {
+              lines.push(`- ${check.label} (actual: ${check.actual})`);
+            }
+          }
+          fs.appendFileSync(process.env.GITHUB_STEP_SUMMARY, `${lines.join("\\n")}\\n`);
+          '
+
+      - name: Upload validation artifacts
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ump-consent-validation-${{ github.run_id }}
+          path: ump-artifacts

--- a/docs/adr/ADR-0008-admob-ump-consent-preflight.md
+++ b/docs/adr/ADR-0008-admob-ump-consent-preflight.md
@@ -61,8 +61,8 @@
 - Privacy options UI（ユーザー再選択導線）の画面実装は別途必要。
 
 ### Follow-ups
-- [ ] Settings画面に「広告のプライバシー設定」導線を追加する Issue を起票
-- [ ] 実機で EEA デバッグ地理 + テスト端末IDを使った確認を CI/Runbook に追加
+- [x] Settings画面に「広告のプライバシー設定」導線を追加する Issue を起票（Issue #82 / PR #83）
+- [x] 実機で EEA デバッグ地理 + テスト端末IDを使った確認を CI/Runbook に追加（Issue #93）
 
 ---
 
@@ -97,4 +97,3 @@
   - iOS: https://developers.google.com/admob/ios/privacy
 - AdMob EU User Consent Policy:
   - https://support.google.com/admob/answer/7666519?hl=en
-

--- a/docs/how-to/android_ビルド手順.md
+++ b/docs/how-to/android_ビルド手順.md
@@ -140,4 +140,6 @@ ADMOB_CONSENT_TEST_DEVICE_IDS=<テスト端末IDをカンマ区切り>
 
 ### 5-3. 事故防止の固定ルール
 - 同意関連の設定変更がある場合は `docs/adr/ADR-0008-admob-ump-consent-preflight.md` を参照
+- 実行手順の正は `docs/how-to/testing.md` の「9. UMP EEA 同意検証（Issue #93）」を参照
+- GitHub Actionsで反復確認する場合は `ump-consent-validation.yml` を `workflow_dispatch` で実行
 - どうしても同意フローが壊れた場合は、リリース前に広告表示を停止して提出する（審査優先）

--- a/docs/how-to/ios_ビルド手順.md
+++ b/docs/how-to/ios_ビルド手順.md
@@ -152,3 +152,5 @@ ADMOB_USER_TRACKING_USAGE_DESCRIPTION=<追跡利用理由の文言>
 ### 6-3. 審査提出前の最終確認
 - App Store Connect の Privacy Policy URL が設定済みであること
 - 同意フロー変更時は `docs/adr/ADR-0008-admob-ump-consent-preflight.md` の差分を確認すること
+- 実行手順の正は `docs/how-to/testing.md` の「9. UMP EEA 同意検証（Issue #93）」を参照
+- GitHub Actionsで反復確認する場合は `ump-consent-validation.yml` を `workflow_dispatch` で実行

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "test:e2e": "maestro test maestro/flows",
     "i18n:audit": "node scripts/i18n-audit.mjs",
     "i18n:inventory": "node scripts/i18n-audit.mjs --inventory --out docs/how-to/i18n_key_inventory.md",
+    "ump:consent:check": "node scripts/ump-consent-check.mjs",
     "prebuild": "expo prebuild",
     "build:android": "expo prebuild --platform android && cd android && ./gradlew bundleRelease"
   },

--- a/scripts/ump-consent-check.mjs
+++ b/scripts/ump-consent-check.mjs
@@ -1,0 +1,197 @@
+import fs from 'node:fs';
+import path from 'node:path';
+
+const ROOT = process.cwd();
+const SUPPORTED_PLATFORMS = new Set(['android', 'ios']);
+const SUPPORTED_DEBUG_GEOGRAPHY = new Set([
+  'DISABLED',
+  'EEA',
+  'NOT_EEA',
+  'REGULATED_US_STATE',
+  'OTHER',
+]);
+
+function parseArgs(argv) {
+  const args = {
+    platform: 'android',
+    debugGeography: 'EEA',
+    testDeviceIds: '',
+    notes: '',
+    out: null,
+    json: false,
+  };
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--json') {
+      args.json = true;
+      continue;
+    }
+    if (token === '--platform') {
+      args.platform = argv[i + 1] ?? '';
+      i += 1;
+      continue;
+    }
+    if (token === '--debug-geography') {
+      args.debugGeography = argv[i + 1] ?? '';
+      i += 1;
+      continue;
+    }
+    if (token === '--test-device-ids') {
+      args.testDeviceIds = argv[i + 1] ?? '';
+      i += 1;
+      continue;
+    }
+    if (token === '--notes') {
+      args.notes = argv[i + 1] ?? '';
+      i += 1;
+      continue;
+    }
+    if (token === '--out') {
+      args.out = argv[i + 1] ?? '';
+      i += 1;
+      continue;
+    }
+  }
+
+  return args;
+}
+
+function normalizeDebugGeography(value) {
+  return String(value ?? '')
+    .trim()
+    .toUpperCase()
+    .replace(/-/g, '_');
+}
+
+function parseTestDeviceIds(value) {
+  const ids = String(value ?? '')
+    .split(',')
+    .map((token) => token.trim())
+    .filter(Boolean);
+  return [...new Set(ids)];
+}
+
+function evaluateConfig(args) {
+  const platform = String(args.platform ?? '').toLowerCase().trim();
+  const debugGeography = normalizeDebugGeography(args.debugGeography);
+  const testDeviceIds = parseTestDeviceIds(args.testDeviceIds);
+
+  const checks = [
+    {
+      key: 'platform',
+      label: 'Platform is android or ios',
+      ok: SUPPORTED_PLATFORMS.has(platform),
+      actual: platform || '(empty)',
+    },
+    {
+      key: 'debugGeographySupported',
+      label: 'Debug geography is supported by react-native-google-mobile-ads',
+      ok: SUPPORTED_DEBUG_GEOGRAPHY.has(debugGeography),
+      actual: debugGeography || '(empty)',
+    },
+    {
+      key: 'debugGeographyIsEea',
+      label: 'Debug geography is EEA for consent validation',
+      ok: debugGeography === 'EEA',
+      actual: debugGeography || '(empty)',
+    },
+    {
+      key: 'testDeviceIdsProvided',
+      label: 'At least one test device ID is provided',
+      ok: testDeviceIds.length > 0,
+      actual: testDeviceIds.length > 0 ? `${testDeviceIds.length} IDs` : '(none)',
+    },
+  ];
+
+  const failedChecks = checks.filter((check) => !check.ok);
+  return {
+    platform,
+    debugGeography,
+    testDeviceIds,
+    checks,
+    failedChecks,
+    passed: failedChecks.length === 0,
+  };
+}
+
+function toMarkdown(report, notes) {
+  const lines = [
+    '# UMP EEA Validation Checklist',
+    '',
+    `- generatedAt: ${new Date().toISOString()}`,
+    `- platform: ${report.platform || '(empty)'}`,
+    `- debugGeography: ${report.debugGeography || '(empty)'}`,
+    `- testDeviceIdsCount: ${report.testDeviceIds.length}`,
+    `- passed: ${report.passed ? 'yes' : 'no'}`,
+    '',
+    '## Validation Checks',
+  ];
+
+  for (const check of report.checks) {
+    const state = check.ok ? 'PASS' : 'FAIL';
+    lines.push(`- [${state}] ${check.label} (actual: ${check.actual})`);
+  }
+
+  if (notes && notes.trim()) {
+    lines.push('', '## Notes', notes.trim());
+  }
+
+  lines.push(
+    '',
+    '## Manual Validation Steps (Free/Pro)',
+    '1. Launch Free plan build with `ADMOB_CONSENT_DEBUG_GEOGRAPHY=EEA`.',
+    '2. Confirm consent flow appears when required.',
+    '3. Confirm banner appears only after `canRequestAds=true`.',
+    '4. Switch to Pro and confirm banner is never mounted.',
+    '',
+    '## Log Points',
+    '- GitHub Actions summary: this report + workflow inputs',
+    '- Android log capture command:',
+    '  - `adb logcat -d | rg "AdsConsent|canRequestAds|privacyOptionsRequirementStatus|AdBanner"`',
+    '- iOS simulator log capture command:',
+    '  - `xcrun simctl spawn booted log stream --predicate \'eventMessage CONTAINS \"AdsConsent\" OR eventMessage CONTAINS \"canRequestAds\"\'`',
+    '',
+    '## Runbook Links',
+    '- `docs/how-to/testing.md`',
+    '- `docs/how-to/android_ビルド手順.md`',
+    '- `docs/how-to/ios_ビルド手順.md`',
+  );
+
+  return `${lines.join('\n')}\n`;
+}
+
+function run() {
+  const args = parseArgs(process.argv.slice(2));
+  const report = evaluateConfig(args);
+
+  if (args.out) {
+    const outPath = path.isAbsolute(args.out) ? args.out : path.join(ROOT, args.out);
+    fs.mkdirSync(path.dirname(outPath), { recursive: true });
+    fs.writeFileSync(outPath, toMarkdown(report, args.notes), 'utf8');
+  }
+
+  if (args.json) {
+    console.log(
+      JSON.stringify(
+        {
+          ...report,
+          notes: args.notes ?? '',
+        },
+        null,
+        2,
+      ),
+    );
+  } else {
+    console.log(`platform: ${report.platform}`);
+    console.log(`debugGeography: ${report.debugGeography}`);
+    console.log(`testDeviceIdsCount: ${report.testDeviceIds.length}`);
+    console.log(`passed: ${report.passed ? 'yes' : 'no'}`);
+  }
+
+  if (!report.passed) {
+    process.exitCode = 1;
+  }
+}
+
+run();


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
Issue #93 に対応し、UMP EEA 同意検証を反復可能にするための手動workflowとrunbookを追加しました。
常時実行はせず、`workflow_dispatch` で必要時にチェックリスト生成・ログ確認を標準化します。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [x] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [ ] test（テスト追加/修正）
- [x] docs（ドキュメント）
- [ ] chore（雑務：依存更新など）
- [ ] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #93
- ADR: docs/adr/ADR-0008-admob-ump-consent-preflight.md
- 参照（1つ以上推奨）:
  - constraints: docs/reference/constraints.md
  - functional_spec: docs/reference/functional_spec.md
  - workflow: docs/how-to/whole_workflow.md
  - spec/notes: docs/how-to/testing.md

---

## 2. 目的（Why / REQUIRED）
- ADR-0008 follow-up の「EEA debug geography + test device IDs の反復検証」を手順化し、回帰時の調査を定型化する。
- 実機検証そのものを常時CI化せず、`workflow_dispatch` で必要時のみ確実に実行できる形にする。

---

## 3. 変更点（What / REQUIRED）
- `.github/workflows/ump-consent-validation.yml` を追加（手動実行workflow）
- `scripts/ump-consent-check.mjs` を追加（入力値検証 + checklist生成）
- `package.json` に `ump:consent:check` script を追加
- `docs/how-to/testing.md` に UMP EEA検証runbook（コマンド意味/ログ確認ポイント）を追加
- Android/iOS build how-to から runbook 参照を追加
- `docs/adr/ADR-0008-admob-ump-consent-preflight.md` の Follow-ups を更新

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] 条件1：`docs/how-to/testing.md` から UMP EEA検証手順を参照可能
- [x] 条件2：`workflow_dispatch` で実行できる検証workflowを追加
- [x] 条件3：失敗時のログ確認ポイントを runbook に明記

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面（UI）: なし
- 機能: UMP検証運用フロー
- 影響する層:
  - [x] Free
  - [ ] Pro
  - [ ] 両方

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし
  - [ ] あり
- 移行（migration）が必要:
  - [x] なし
  - [ ] あり

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [x] なし
  - [ ] あり
- 端末/OS差分の懸念:
  - [ ] なし
  - [x] あり（実機ログ確認コマンドは Android/iOS で分岐）

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト（該当を残す / RECOMMENDED）
- [x] pnpm test（結果：✅）
- [x] pnpm lint（結果：✅）
- [ ] pnpm test:e2e（結果：未実施 / 本PRスコープ外）
- [x] pnpm type-check（結果：✅）
- CI（GitHub Actions）:
  - [ ] 全部 ✅（PR作成後確認）

### 6-2. 手動確認（手順を箇条書き / REQUIRED）
1. `pnpm ump:consent:check -- --platform ios --debug-geography EEA --test-device-ids "AAA"` を実行
2. `node scripts/ump-consent-check.mjs --platform android --debug-geography EEA --test-device-ids "ABC,DEF" --out /tmp/ump-check.md --json` を実行
3. `node scripts/ump-consent-check.mjs --platform android --debug-geography NOT_EEA --test-device-ids ""` が失敗することを確認
- 期待結果: EEA + test device IDs ありで pass、条件不足で fail
- 実際結果: 期待どおり確認済み

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [ ] 仕様/前提/制約が変わる → docs/reference/constraints.md を更新
- [ ] 用語が増える/意味が変わる → docs/reference/glossary.md を更新
- [ ] 運用手順が変わる → docs/how-to/whole_workflow.md を更新
- [ ] リリース手順に影響 → docs/how-to/android_ビルド手順.md / docs/how-to/ios_ビルド手順.md を更新（リンク：更新済み）
- [x] 意思決定が増えた/変わった → docs/adr/ADR-0008-admob-ump-consent-preflight.md を更新
- [ ] テスト観点が変わる → テスト（Jest/Maestro）を追加/更新
- [ ] どれも不要

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク（短く）
- 想定リスク: workflow入力ミスで false negative が出る
- 検知方法（どうやって気づく？）: checklist JSON の failedChecks と run summary
- 影響の大きさ:
  - [x] 低（困るが致命傷ではない）
  - [ ] 中
  - [ ] 高

### 9-2. ロールバック（戻し方 / REQUIRED）
- 戻し方（最短手順）:
  - このPRを revert し、手動runbook運用のみへ戻す
- 影響範囲の切り分け（できれば）:
  - 検証運用フローのみ（本番アプリ挙動には非影響）

---

## 10. セキュリティ / 課金 / 広告（該当時のみ / REQUIRED if 該当）
- [x] Secrets/キーを直書きしていない（APIキー/広告ユニットID/RevenueCat等）
- [x] 個人情報をログ出力していない
- [x] 通信はHTTPS前提で問題ない
- [ ] 課金（RevenueCat）の影響がある
- [x] 広告（AdMob）の影響がある → Freeのみ表示 / Proはゼロ を確認する手順を「6」に追記した
- [x] 外部GitHub Actionsの追加/更新がある → 第三者Actionは commit SHA pin した

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲（UI/機能/データ/Free/Pro）を書いた
- [x] “合否が判定できる” 動作確認を記載した（自動/手動）
- [ ] CIが通った（または通せない理由を明記）
- [x] docs影響を判定し、必要なら更新した（links記載）
- [x] リスクとロールバックを書いた
