### PR TITLE
[Perf] Add reproducible PDF font benchmark and ADR decision (#72)

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -32,6 +32,7 @@
   - 例：`docs/how-to/release_notes_template.md`（タグ命名規則とReleaseノート雛形）
   - 例：`docs/how-to/backup_restore.md`（バックアップ復元と障害切り分け）
   - 例：`docs/how-to/i18n_key_inventory.md`（翻訳キーの使用中/未使用候補の棚卸し）
+  - 例：`docs/how-to/pdf_font_benchmark.md`（PDFフォント性能計測の再実行手順）
 
 ---
 

--- a/docs/adr/ADR-0002-pdf-fonts.md
+++ b/docs/adr/ADR-0002-pdf-fonts.md
@@ -64,8 +64,22 @@
 - PDF生成時のメモリ使用量が増える
 
 ### Follow-ups（後でやる宿題）
-- [ ] PDF生成時に「必要なスクリプトだけ埋め込む」最適化の検討
-- [ ] PDF生成パフォーマンス計測
+- [x] PDF生成時に「必要なスクリプトだけ埋め込む」最適化の検討（Issue #72）
+- [x] PDF生成パフォーマンス計測（Issue #72）
+
+### 2026-02-10 Follow-up結果（Issue #72）
+- 実測結果（`docs/how-to/benchmarks/pdf_font_benchmark.latest.md`）:
+  - 短文シナリオ：`all_fonts` 66.93MB → `script_subset` 2.61MB（font payload）
+  - 多言語シナリオ：`all_fonts` 66.93MB → `script_subset` 29.14MB
+  - warm中央値：短文で約96.8%短縮、多言語で約54.7%短縮
+- 判断（採用/非採用）:
+  - **v1.0.x では runtime の script subset 最適化は採用しない（保留）**
+  - 理由:
+    - CJKは文字集合の重なりが大きく、文字種推定だけで `JP/SC/TC` を誤判定するリスクがある
+    - 誤判定時は文字化け/豆腐化が発生し、Repologの最優先価値（提出品質）を損なう
+  - 継続方針:
+    - 現行の全フォント埋め込みを維持し、ベンチ基盤で継続測定する
+    - 実機の回帰テスト条件を満たせる段階で、段階導入を再検討する
 
 ---
 
@@ -89,7 +103,10 @@
 - constraints: `docs/reference/constraints.md`
 - reference: `docs/reference/basic_spec.md` / `docs/reference/functional_spec.md`
 - Issue: #5
+- Issue: #72
 - PR: #TBD
+- Benchmark runbook: `docs/how-to/pdf_font_benchmark.md`
+- Benchmark result: `docs/how-to/benchmarks/pdf_font_benchmark.latest.md`
 - External docs: https://scripts.sil.org/OFL
 
 ---

--- a/docs/how-to/benchmarks/pdf_font_benchmark.latest.json
+++ b/docs/how-to/benchmarks/pdf_font_benchmark.latest.json
@@ -1,0 +1,286 @@
+{
+  "benchmarkedAtUtc": "2026-02-10T09:11:44.784Z",
+  "environment": {
+    "node": "v18.20.8",
+    "platform": "linux",
+    "arch": "x64"
+  },
+  "settings": {
+    "iterations": 7,
+    "sampleImagePath": "assets/images/icon.png",
+    "sampleImageRawBytes": 393493,
+    "sampleImageDataUriBytes": 524682,
+    "baseTemplateBytes": 4096
+  },
+  "scenarios": [
+    {
+      "id": "short_text",
+      "label": "Short text / low photo count",
+      "localeHint": "en",
+      "photoCount": 4,
+      "textLength": 123,
+      "results": {
+        "all_fonts": {
+          "selectedFontKeys": [
+            "latin",
+            "jp",
+            "sc",
+            "tc",
+            "kr",
+            "thai",
+            "devanagari"
+          ],
+          "selectedFontFamilies": [
+            "Noto Sans",
+            "Noto Sans JP",
+            "Noto Sans SC",
+            "Noto Sans TC",
+            "Noto Sans KR",
+            "Noto Sans Thai",
+            "Noto Sans Devanagari"
+          ],
+          "bytes": {
+            "rawFontBytes": 52633648,
+            "base64FontBytes": 70178204,
+            "cssBytes": 70179246,
+            "textBytes": 123,
+            "samplePhotoDataUriBytes": 524682,
+            "estimatedPhotoBytes": 2098728,
+            "estimatedPdfInputBytes": 72282193
+          },
+          "cold": {
+            "timingsMs": {
+              "total": 91.369,
+              "select": 0.028,
+              "encode": 47.856,
+              "css": 36.026
+            },
+            "rssDeltaMb": 180.887
+          },
+          "warm": {
+            "runCount": 6,
+            "totalMedianMs": 32.779,
+            "totalP90Ms": 34.708,
+            "encodeMedianMs": 0.014,
+            "encodeP90Ms": 0.026
+          }
+        },
+        "script_subset": {
+          "selectedFontKeys": [
+            "latin"
+          ],
+          "selectedFontFamilies": [
+            "Noto Sans"
+          ],
+          "bytes": {
+            "rawFontBytes": 2049096,
+            "base64FontBytes": 2732128,
+            "cssBytes": 2732272,
+            "textBytes": 123,
+            "samplePhotoDataUriBytes": 524682,
+            "estimatedPhotoBytes": 2098728,
+            "estimatedPdfInputBytes": 4835219
+          },
+          "cold": {
+            "timingsMs": {
+              "total": 3.564,
+              "select": 0.138,
+              "encode": 2.395,
+              "css": 0.004
+            },
+            "rssDeltaMb": 6.938
+          },
+          "warm": {
+            "runCount": 6,
+            "totalMedianMs": 1.033,
+            "totalP90Ms": 1.133,
+            "encodeMedianMs": 0.003,
+            "encodeP90Ms": 0.005
+          }
+        }
+      }
+    },
+    {
+      "id": "photo_heavy",
+      "label": "Photo heavy / same language",
+      "localeHint": "en",
+      "photoCount": 80,
+      "textLength": 152,
+      "results": {
+        "all_fonts": {
+          "selectedFontKeys": [
+            "latin",
+            "jp",
+            "sc",
+            "tc",
+            "kr",
+            "thai",
+            "devanagari"
+          ],
+          "selectedFontFamilies": [
+            "Noto Sans",
+            "Noto Sans JP",
+            "Noto Sans SC",
+            "Noto Sans TC",
+            "Noto Sans KR",
+            "Noto Sans Thai",
+            "Noto Sans Devanagari"
+          ],
+          "bytes": {
+            "rawFontBytes": 52633648,
+            "base64FontBytes": 70178204,
+            "cssBytes": 70179246,
+            "textBytes": 152,
+            "samplePhotoDataUriBytes": 524682,
+            "estimatedPhotoBytes": 41974560,
+            "estimatedPdfInputBytes": 112158054
+          },
+          "cold": {
+            "timingsMs": {
+              "total": 61.295,
+              "select": 0.003,
+              "encode": 30.856,
+              "css": 24.637
+            },
+            "rssDeltaMb": 179.625
+          },
+          "warm": {
+            "runCount": 6,
+            "totalMedianMs": 33.159,
+            "totalP90Ms": 34.863,
+            "encodeMedianMs": 0.01,
+            "encodeP90Ms": 0.013
+          }
+        },
+        "script_subset": {
+          "selectedFontKeys": [
+            "latin"
+          ],
+          "selectedFontFamilies": [
+            "Noto Sans"
+          ],
+          "bytes": {
+            "rawFontBytes": 2049096,
+            "base64FontBytes": 2732128,
+            "cssBytes": 2732272,
+            "textBytes": 152,
+            "samplePhotoDataUriBytes": 524682,
+            "estimatedPhotoBytes": 41974560,
+            "estimatedPdfInputBytes": 44711080
+          },
+          "cold": {
+            "timingsMs": {
+              "total": 3.099,
+              "select": 0.129,
+              "encode": 1.902,
+              "css": 0.003
+            },
+            "rssDeltaMb": 6.563
+          },
+          "warm": {
+            "runCount": 6,
+            "totalMedianMs": 1.189,
+            "totalP90Ms": 1.311,
+            "encodeMedianMs": 0.003,
+            "encodeP90Ms": 0.004
+          }
+        }
+      }
+    },
+    {
+      "id": "multilingual",
+      "label": "Multilingual scripts / medium photo count",
+      "localeHint": "ja",
+      "photoCount": 12,
+      "textLength": 60,
+      "results": {
+        "all_fonts": {
+          "selectedFontKeys": [
+            "latin",
+            "jp",
+            "sc",
+            "tc",
+            "kr",
+            "thai",
+            "devanagari"
+          ],
+          "selectedFontFamilies": [
+            "Noto Sans",
+            "Noto Sans JP",
+            "Noto Sans SC",
+            "Noto Sans TC",
+            "Noto Sans KR",
+            "Noto Sans Thai",
+            "Noto Sans Devanagari"
+          ],
+          "bytes": {
+            "rawFontBytes": 52633648,
+            "base64FontBytes": 70178204,
+            "cssBytes": 70179246,
+            "textBytes": 164,
+            "samplePhotoDataUriBytes": 524682,
+            "estimatedPhotoBytes": 6296184,
+            "estimatedPdfInputBytes": 76479690
+          },
+          "cold": {
+            "timingsMs": {
+              "total": 61.242,
+              "select": 0.01,
+              "encode": 30.782,
+              "css": 24.202
+            },
+            "rssDeltaMb": 179.625
+          },
+          "warm": {
+            "runCount": 6,
+            "totalMedianMs": 31.641,
+            "totalP90Ms": 31.815,
+            "encodeMedianMs": 0.012,
+            "encodeP90Ms": 0.013
+          }
+        },
+        "script_subset": {
+          "selectedFontKeys": [
+            "latin",
+            "devanagari",
+            "thai",
+            "kr",
+            "jp"
+          ],
+          "selectedFontFamilies": [
+            "Noto Sans",
+            "Noto Sans Devanagari",
+            "Noto Sans Thai",
+            "Noto Sans KR",
+            "Noto Sans JP"
+          ],
+          "bytes": {
+            "rawFontBytes": 22919380,
+            "base64FontBytes": 30559180,
+            "cssBytes": 30559926,
+            "textBytes": 164,
+            "samplePhotoDataUriBytes": 524682,
+            "estimatedPhotoBytes": 6296184,
+            "estimatedPdfInputBytes": 36860370
+          },
+          "cold": {
+            "timingsMs": {
+              "total": 29.52,
+              "select": 0.141,
+              "encode": 15.117,
+              "css": 10.636
+            },
+            "rssDeltaMb": 79.875
+          },
+          "warm": {
+            "runCount": 6,
+            "totalMedianMs": 14.34,
+            "totalP90Ms": 15.886,
+            "encodeMedianMs": 0.009,
+            "encodeP90Ms": 0.011
+          }
+        }
+      }
+    }
+  ]
+}

--- a/docs/how-to/benchmarks/pdf_font_benchmark.latest.md
+++ b/docs/how-to/benchmarks/pdf_font_benchmark.latest.md
@@ -1,0 +1,34 @@
+# PDF Font Benchmark (Issue #72)
+
+- Benchmarked at (UTC): 2026-02-10T09:11:44.784Z
+- Node: v18.20.8
+- Platform: linux/x64
+- Iterations per scenario: 7
+- Sample image: `assets/images/icon.png`
+- Sample image raw bytes: 393493
+- Sample image data URI bytes: 524682
+
+## Summary
+
+| Scenario | Strategy | Fonts | Font payload (MB, base64) | Estimated PDF input (MB) | Cold total (ms) | Warm median (ms) |
+| --- | --- | --- | ---: | ---: | ---: | ---: |
+| Short text / low photo count | all_fonts | 7 | 66.93 | 68.93 | 91.37 | 32.78 |
+| Short text / low photo count | script_subset | 1 | 2.61 | 4.61 | 3.56 | 1.03 |
+| Photo heavy / same language | all_fonts | 7 | 66.93 | 106.96 | 61.30 | 33.16 |
+| Photo heavy / same language | script_subset | 1 | 2.61 | 42.64 | 3.10 | 1.19 |
+| Multilingual scripts / medium photo count | all_fonts | 7 | 66.93 | 72.94 | 61.24 | 31.64 |
+| Multilingual scripts / medium photo count | script_subset | 5 | 29.14 | 35.15 | 29.52 | 14.34 |
+
+## Delta (script_subset vs all_fonts)
+
+| Scenario | Font payload reduction | Estimated input reduction | Warm median speedup |
+| --- | ---: | ---: | ---: |
+| Short text / low photo count | 96.1% | 93.3% | 96.8% |
+| Photo heavy / same language | 96.1% | 60.1% | 96.4% |
+| Multilingual scripts / medium photo count | 56.5% | 51.8% | 54.7% |
+
+## Notes
+
+- This benchmark measures the font embedding path and estimated PDF input size.
+- Estimated size uses one fixed sample image payload for repeatability.
+- Real device PDF size/time still depends on actual photo content and native print engine behavior.

--- a/docs/how-to/pdf_font_benchmark.md
+++ b/docs/how-to/pdf_font_benchmark.md
@@ -1,0 +1,102 @@
+# docs/how-to/pdf_font_benchmark.md
+
+# PDFフォント性能ベンチマーク（Issue #72）
+
+この文書は「PDFフォント埋め込みの重さ」を、同じ条件で何度でも測るための手順書です。  
+目的は、`ADR-0002` の Follow-up（最適化検討/性能計測）を再現可能にすることです。
+
+---
+
+## 1. 何を測るか
+
+このベンチマークは、次の2戦略を比較します。
+
+- `all_fonts`：
+  - 現行実装と同じく、Noto Sans系7フォントを常に埋め込む
+- `script_subset`：
+  - テキストに含まれる文字種（ラテン/CJK/ハングル/タイ/デーヴァナーガリー）から必要フォントだけを選ぶ
+
+測定値:
+- フォントpayload（base64化後サイズ）
+- 推定PDF入力サイズ（フォント + 文章 + サンプル画像分）
+- 実行時間
+  - `cold`（初回、読み込みあり）
+  - `warm`（キャッシュ後）
+
+---
+
+## 2. 実行コマンド（最短）
+
+```bash
+pnpm pdf:font:benchmark
+```
+
+コマンドの意味:
+- `pnpm`：
+  - `package.json` の `scripts` を実行するコマンドランナー
+- `pdf:font:benchmark`：
+  - `node --expose-gc scripts/pdf-font-benchmark.mjs` を呼び出す
+- `node --expose-gc`：
+  - Node.js の `global.gc()` を有効化し、cold runのメモリ差分を安定化しやすくする
+- `scripts/pdf-font-benchmark.mjs`：
+  - 実際の計測スクリプト
+
+---
+
+## 3. オプション付き実行
+
+```bash
+node --expose-gc scripts/pdf-font-benchmark.mjs \
+  --iterations 9 \
+  --sample-image assets/images/icon.png \
+  --out-json docs/how-to/benchmarks/pdf_font_benchmark.custom.json \
+  --out-md docs/how-to/benchmarks/pdf_font_benchmark.custom.md
+```
+
+各オプションの意味:
+- `--iterations 9`：
+  - 1シナリオあたり9回計測（1回目=cold、残り=warm集計）
+- `--sample-image <path>`：
+  - 1枚あたりの画像payload推定に使うサンプル画像
+- `--out-json <path>`：
+  - 生データ（集計済みJSON）の出力先
+- `--out-md <path>`：
+  - 表形式レポート（Markdown）の出力先
+
+---
+
+## 4. 出力ファイル
+
+デフォルトでは次に保存されます。
+
+- `docs/how-to/benchmarks/pdf_font_benchmark.latest.json`
+- `docs/how-to/benchmarks/pdf_font_benchmark.latest.md`
+
+---
+
+## 5. 最新実測（2026-02-10 UTC）
+
+実行条件:
+- Node: `v18.20.8`
+- Platform: `linux/x64`
+- Iterations: `7`
+- Sample image: `assets/images/icon.png`（raw `393,493` bytes）
+
+結果サマリ（抜粋）:
+- 短文シナリオ（4枚）:
+  - `all_fonts`: font payload `66.93 MB`, warm中央値 `32.78 ms`
+  - `script_subset`: font payload `2.61 MB`, warm中央値 `1.03 ms`
+- 多写真シナリオ（80枚）:
+  - `all_fonts`: 推定入力 `106.96 MB`
+  - `script_subset`: 推定入力 `42.64 MB`
+- 多言語シナリオ（12枚）:
+  - `all_fonts`: font payload `66.93 MB`
+  - `script_subset`: font payload `29.14 MB`
+
+---
+
+## 6. 読み方の注意
+
+- これは「フォント埋め込み経路」の比較ベンチです。
+- 実機の最終PDFサイズ/生成時間は、写真内容・端末性能・ネイティブ印刷エンジンで変動します。
+- そのため、最終採用判断は `ADR-0002` の追記を正とします。

--- a/docs/how-to/testing.md
+++ b/docs/how-to/testing.md
@@ -505,7 +505,53 @@ xcrun simctl spawn booted log stream \
 
 ---
 
-## 10. 最後のチェックリスト（PR前）
+## 10. PDFフォント性能ベンチ（Issue #72）
+
+目的:
+- `ADR-0002` の Follow-up（フォント最適化検討 / 性能計測）を再実行可能にする
+- 3条件（短文/多写真/多言語）で比較結果を残す
+
+最短コマンド:
+```bash
+pnpm pdf:font:benchmark
+```
+
+コマンドの意味:
+- `pnpm`:
+  - `package.json` の scripts を実行する
+- `pdf:font:benchmark`:
+  - `node --expose-gc scripts/pdf-font-benchmark.mjs` を実行する
+- `--expose-gc`:
+  - NodeのGC呼び出しを有効化し、cold run計測のノイズを減らす
+
+成果物（デフォルト）:
+- `docs/how-to/benchmarks/pdf_font_benchmark.latest.json`
+- `docs/how-to/benchmarks/pdf_font_benchmark.latest.md`
+
+追加オプション例:
+```bash
+node --expose-gc scripts/pdf-font-benchmark.mjs \
+  --iterations 9 \
+  --sample-image assets/images/icon.png \
+  --out-json docs/how-to/benchmarks/pdf_font_benchmark.custom.json \
+  --out-md docs/how-to/benchmarks/pdf_font_benchmark.custom.md
+```
+
+オプションの意味:
+- `--iterations`:
+  - シナリオごとの実行回数（1回目がcold、残りがwarm集計）
+- `--sample-image`:
+  - 1枚あたりの画像payload推定に使うファイル
+- `--out-json` / `--out-md`:
+  - 出力先ファイルを指定
+
+補足:
+- 計測の読み方と最新結果は `docs/how-to/pdf_font_benchmark.md` を正とする
+- 採用/非採用の最終判断は `docs/adr/ADR-0002-pdf-fonts.md` を正とする
+
+---
+
+## 11. 最後のチェックリスト（PR前）
 
 * [ ] `pnpm lint` OK
 * [ ] `pnpm type-check` OK

--- a/package.json
+++ b/package.json
@@ -15,6 +15,7 @@
     "i18n:audit": "node scripts/i18n-audit.mjs",
     "i18n:inventory": "node scripts/i18n-audit.mjs --inventory --out docs/how-to/i18n_key_inventory.md",
     "ump:consent:check": "node scripts/ump-consent-check.mjs",
+    "pdf:font:benchmark": "node --expose-gc scripts/pdf-font-benchmark.mjs",
     "prebuild": "expo prebuild",
     "build:android": "expo prebuild --platform android && cd android && ./gradlew bundleRelease"
   },

--- a/scripts/pdf-font-benchmark.mjs
+++ b/scripts/pdf-font-benchmark.mjs
@@ -1,0 +1,520 @@
+#!/usr/bin/env node
+
+import fs from 'node:fs/promises';
+import path from 'node:path';
+import process from 'node:process';
+import { Buffer } from 'node:buffer';
+import { performance } from 'node:perf_hooks';
+
+const KB = 1024;
+const MB = KB * KB;
+const BASE_TEMPLATE_BYTES = 4 * KB;
+const DATA_URI_PREFIX = 'data:image/png;base64,';
+
+const FONT_CATALOG = [
+  {
+    key: 'latin',
+    family: 'Noto Sans',
+    filePath: 'assets/fonts/NotoSans-Variable.ttf',
+  },
+  {
+    key: 'jp',
+    family: 'Noto Sans JP',
+    filePath: 'assets/fonts/NotoSansJP-Variable.ttf',
+  },
+  {
+    key: 'sc',
+    family: 'Noto Sans SC',
+    filePath: 'assets/fonts/NotoSansSC-Variable.ttf',
+  },
+  {
+    key: 'tc',
+    family: 'Noto Sans TC',
+    filePath: 'assets/fonts/NotoSansTC-Variable.ttf',
+  },
+  {
+    key: 'kr',
+    family: 'Noto Sans KR',
+    filePath: 'assets/fonts/NotoSansKR-Variable.ttf',
+  },
+  {
+    key: 'thai',
+    family: 'Noto Sans Thai',
+    filePath: 'assets/fonts/NotoSansThai-Variable.ttf',
+  },
+  {
+    key: 'devanagari',
+    family: 'Noto Sans Devanagari',
+    filePath: 'assets/fonts/NotoSansDevanagari-Variable.ttf',
+  },
+];
+
+const SCENARIOS = [
+  {
+    id: 'short_text',
+    label: 'Short text / low photo count',
+    localeHint: 'en',
+    photoCount: 4,
+    reportName: 'Bridge inspection',
+    comment:
+      'Checked anchors and guard rails. No visible damage. Next routine check is scheduled for tomorrow morning.',
+  },
+  {
+    id: 'photo_heavy',
+    label: 'Photo heavy / same language',
+    localeHint: 'en',
+    photoCount: 80,
+    reportName: 'Warehouse post-rain patrol',
+    comment:
+      'Large route patrol with many evidence photos. Findings are mostly normal, but drainage around loading dock B needs follow-up.',
+  },
+  {
+    id: 'multilingual',
+    label: 'Multilingual scripts / medium photo count',
+    localeHint: 'ja',
+    photoCount: 12,
+    reportName: '多言語点検レポート',
+    comment:
+      '日本語とEnglishを混在。简体中文・繁體中文・한국어・ไทย・हिन्दीを含む確認用コメント。',
+  },
+];
+
+const SCRIPT_REGEX = {
+  devanagari: /[\u0900-\u097F]/u,
+  thai: /[\u0E00-\u0E7F]/u,
+  hangul: /[\u1100-\u11FF\u3130-\u318F\uAC00-\uD7AF]/u,
+  hiraganaKatakana: /[\u3040-\u30FF]/u,
+  cjkUnified: /[\u3400-\u4DBF\u4E00-\u9FFF\uF900-\uFAFF]/u,
+};
+
+const DEFAULTS = {
+  iterations: 7,
+  sampleImagePath: 'assets/images/icon.png',
+  outJsonPath: 'docs/how-to/benchmarks/pdf_font_benchmark.latest.json',
+  outMarkdownPath: 'docs/how-to/benchmarks/pdf_font_benchmark.latest.md',
+  write: true,
+};
+
+function printUsage() {
+  console.log(`Usage: node scripts/pdf-font-benchmark.mjs [options]
+
+Options:
+  --iterations <number>      Number of runs per scenario/strategy (default: ${DEFAULTS.iterations})
+  --sample-image <path>      Sample image used for size estimation (default: ${DEFAULTS.sampleImagePath})
+  --out-json <path>          JSON output path (default: ${DEFAULTS.outJsonPath})
+  --out-md <path>            Markdown output path (default: ${DEFAULTS.outMarkdownPath})
+  --no-write                 Run benchmark but do not write files
+  -h, --help                 Show this help
+`);
+}
+
+function parseArgs(argv) {
+  const args = { ...DEFAULTS };
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i];
+    if (token === '--iterations') {
+      const raw = argv[i + 1];
+      const parsed = Number.parseInt(raw ?? '', 10);
+      if (!Number.isInteger(parsed) || parsed < 1) {
+        throw new Error(`Invalid value for --iterations: ${raw ?? '(missing)'}`);
+      }
+      args.iterations = parsed;
+      i += 1;
+      continue;
+    }
+    if (token === '--sample-image') {
+      args.sampleImagePath = argv[i + 1] ?? '';
+      i += 1;
+      continue;
+    }
+    if (token === '--out-json') {
+      args.outJsonPath = argv[i + 1] ?? '';
+      i += 1;
+      continue;
+    }
+    if (token === '--out-md') {
+      args.outMarkdownPath = argv[i + 1] ?? '';
+      i += 1;
+      continue;
+    }
+    if (token === '--no-write') {
+      args.write = false;
+      continue;
+    }
+    if (token === '-h' || token === '--help') {
+      args.help = true;
+      continue;
+    }
+    throw new Error(`Unknown option: ${token}`);
+  }
+
+  return args;
+}
+
+const fontBase64Cache = new Map();
+
+function toPercent(value) {
+  if (!Number.isFinite(value)) return 'n/a';
+  return `${(value * 100).toFixed(1)}%`;
+}
+
+function bytesToMb(value) {
+  return value / MB;
+}
+
+function base64Length(rawBytes) {
+  return Math.ceil(rawBytes / 3) * 4;
+}
+
+function round(value, digits = 2) {
+  const factor = 10 ** digits;
+  return Math.round(value * factor) / factor;
+}
+
+function median(values) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const middle = Math.floor(sorted.length / 2);
+  if (sorted.length % 2 === 0) {
+    return (sorted[middle - 1] + sorted[middle]) / 2;
+  }
+  return sorted[middle];
+}
+
+function percentile(values, percentileValue) {
+  if (values.length === 0) return null;
+  const sorted = [...values].sort((a, b) => a - b);
+  const index = Math.max(
+    0,
+    Math.min(sorted.length - 1, Math.ceil((percentileValue / 100) * sorted.length) - 1),
+  );
+  return sorted[index];
+}
+
+function detectScriptSubset(text, localeHint) {
+  const selected = new Set(['latin']);
+  if (SCRIPT_REGEX.devanagari.test(text)) {
+    selected.add('devanagari');
+  }
+  if (SCRIPT_REGEX.thai.test(text)) {
+    selected.add('thai');
+  }
+  if (SCRIPT_REGEX.hangul.test(text)) {
+    selected.add('kr');
+  }
+  if (SCRIPT_REGEX.hiraganaKatakana.test(text)) {
+    selected.add('jp');
+  }
+  if (SCRIPT_REGEX.cjkUnified.test(text)) {
+    if (localeHint === 'ja') {
+      selected.add('jp');
+    } else if (localeHint === 'zh-Hans') {
+      selected.add('sc');
+    } else if (localeHint === 'zh-Hant') {
+      selected.add('tc');
+    } else {
+      // When locale is unknown, keep CJK-safe fallback to avoid false negatives.
+      selected.add('jp');
+      selected.add('sc');
+      selected.add('tc');
+    }
+  }
+  return [...selected];
+}
+
+function selectFontKeys(strategy, scenario) {
+  if (strategy === 'all_fonts') {
+    return FONT_CATALOG.map((font) => font.key);
+  }
+  if (strategy === 'script_subset') {
+    const text = `${scenario.reportName}\n${scenario.comment}`;
+    return detectScriptSubset(text, scenario.localeHint);
+  }
+  throw new Error(`Unknown strategy: ${strategy}`);
+}
+
+async function readFontMetadata(rootDir) {
+  const out = {};
+  for (const font of FONT_CATALOG) {
+    const absolutePath = path.join(rootDir, font.filePath);
+    const stats = await fs.stat(absolutePath);
+    out[font.key] = {
+      ...font,
+      absolutePath,
+      rawBytes: stats.size,
+      base64Bytes: base64Length(stats.size),
+    };
+  }
+  return out;
+}
+
+async function loadFontBase64(fontMeta, useCache) {
+  if (useCache && fontBase64Cache.has(fontMeta.key)) {
+    return fontBase64Cache.get(fontMeta.key);
+  }
+
+  const buffer = await fs.readFile(fontMeta.absolutePath);
+  const encoded = buffer.toString('base64');
+  if (useCache) {
+    fontBase64Cache.set(fontMeta.key, encoded);
+  }
+  return encoded;
+}
+
+function buildFontCss(selectedFontMeta, encodedByFontKey) {
+  return selectedFontMeta
+    .map((fontMeta) => {
+      const encoded = encodedByFontKey[fontMeta.key];
+      return `@font-face {\n  font-family: '${fontMeta.family}';\n  src: url('data:font/ttf;base64,${encoded}') format('truetype');\n  font-weight: 100 900;\n  font-style: normal;\n}`;
+    })
+    .join('\n');
+}
+
+async function benchmarkOneRun({
+  scenario,
+  strategy,
+  fontMetaMap,
+  sampleImageDataUriBytes,
+  runIndex,
+}) {
+  const isColdRun = runIndex === 0;
+  if (isColdRun) {
+    fontBase64Cache.clear();
+    if (typeof global.gc === 'function') {
+      global.gc();
+    }
+  }
+
+  const memoryBefore = process.memoryUsage();
+  const totalStart = performance.now();
+
+  const selectStart = performance.now();
+  const selectedKeys = selectFontKeys(strategy, scenario);
+  const selectedFontMeta = selectedKeys.map((key) => fontMetaMap[key]);
+  const selectMs = performance.now() - selectStart;
+
+  const encodeStart = performance.now();
+  const encodedList = await Promise.all(
+    selectedFontMeta.map(async (fontMeta) => [fontMeta.key, await loadFontBase64(fontMeta, true)]),
+  );
+  const encodeMs = performance.now() - encodeStart;
+  const encodedByFontKey = Object.fromEntries(encodedList);
+
+  const cssStart = performance.now();
+  const css = buildFontCss(selectedFontMeta, encodedByFontKey);
+  const cssMs = performance.now() - cssStart;
+  const cssBytes = Buffer.byteLength(css, 'utf8');
+
+  const textPayload = `${scenario.reportName}\n${scenario.comment}`;
+  const textBytes = Buffer.byteLength(textPayload, 'utf8');
+  const photoBytes = scenario.photoCount * sampleImageDataUriBytes;
+  const estimatedPdfInputBytes = BASE_TEMPLATE_BYTES + cssBytes + textBytes + photoBytes;
+
+  const rawFontBytes = selectedFontMeta.reduce((sum, fontMeta) => sum + fontMeta.rawBytes, 0);
+  const base64FontBytes = selectedFontMeta.reduce((sum, fontMeta) => sum + fontMeta.base64Bytes, 0);
+
+  const totalMs = performance.now() - totalStart;
+  const memoryAfter = process.memoryUsage();
+
+  return {
+    isColdRun,
+    selectedFontKeys: selectedKeys,
+    selectedFontFamilies: selectedFontMeta.map((fontMeta) => fontMeta.family),
+    timingsMs: {
+      total: round(totalMs, 3),
+      select: round(selectMs, 3),
+      encode: round(encodeMs, 3),
+      css: round(cssMs, 3),
+    },
+    bytes: {
+      rawFontBytes,
+      base64FontBytes,
+      cssBytes,
+      textBytes,
+      samplePhotoDataUriBytes: sampleImageDataUriBytes,
+      estimatedPhotoBytes: photoBytes,
+      estimatedPdfInputBytes,
+    },
+    memory: {
+      heapUsedBefore: memoryBefore.heapUsed,
+      heapUsedAfter: memoryAfter.heapUsed,
+      rssBefore: memoryBefore.rss,
+      rssAfter: memoryAfter.rss,
+      rssDelta: memoryAfter.rss - memoryBefore.rss,
+    },
+  };
+}
+
+function summarizeRuns(runs) {
+  if (runs.length === 0) {
+    throw new Error('No benchmark runs found.');
+  }
+
+  const coldRun = runs.find((run) => run.isColdRun) ?? runs[0];
+  const warmRuns = runs.filter((run) => !run.isColdRun);
+  const warmTotal = warmRuns.map((run) => run.timingsMs.total);
+  const warmEncode = warmRuns.map((run) => run.timingsMs.encode);
+
+  return {
+    selectedFontKeys: coldRun.selectedFontKeys,
+    selectedFontFamilies: coldRun.selectedFontFamilies,
+    bytes: coldRun.bytes,
+    cold: {
+      timingsMs: coldRun.timingsMs,
+      rssDeltaMb: round(bytesToMb(coldRun.memory.rssDelta), 3),
+    },
+    warm: {
+      runCount: warmRuns.length,
+      totalMedianMs: round(median(warmTotal) ?? 0, 3),
+      totalP90Ms: round(percentile(warmTotal, 90) ?? 0, 3),
+      encodeMedianMs: round(median(warmEncode) ?? 0, 3),
+      encodeP90Ms: round(percentile(warmEncode, 90) ?? 0, 3),
+    },
+  };
+}
+
+function buildMarkdown(report) {
+  const lines = [];
+  lines.push('# PDF Font Benchmark (Issue #72)');
+  lines.push('');
+  lines.push(`- Benchmarked at (UTC): ${report.benchmarkedAtUtc}`);
+  lines.push(`- Node: ${report.environment.node}`);
+  lines.push(`- Platform: ${report.environment.platform}/${report.environment.arch}`);
+  lines.push(`- Iterations per scenario: ${report.settings.iterations}`);
+  lines.push(`- Sample image: \`${report.settings.sampleImagePath}\``);
+  lines.push(`- Sample image raw bytes: ${report.settings.sampleImageRawBytes}`);
+  lines.push(`- Sample image data URI bytes: ${report.settings.sampleImageDataUriBytes}`);
+  lines.push('');
+  lines.push('## Summary');
+  lines.push('');
+  lines.push(
+    '| Scenario | Strategy | Fonts | Font payload (MB, base64) | Estimated PDF input (MB) | Cold total (ms) | Warm median (ms) |',
+  );
+  lines.push('| --- | --- | --- | ---: | ---: | ---: | ---: |');
+
+  for (const scenario of report.scenarios) {
+    for (const strategyName of ['all_fonts', 'script_subset']) {
+      const strategy = scenario.results[strategyName];
+      lines.push(
+        `| ${scenario.label} | ${strategyName} | ${strategy.selectedFontKeys.length} | ${bytesToMb(strategy.bytes.base64FontBytes).toFixed(2)} | ${bytesToMb(strategy.bytes.estimatedPdfInputBytes).toFixed(2)} | ${strategy.cold.timingsMs.total.toFixed(2)} | ${strategy.warm.totalMedianMs.toFixed(2)} |`,
+      );
+    }
+  }
+
+  lines.push('');
+  lines.push('## Delta (script_subset vs all_fonts)');
+  lines.push('');
+  lines.push('| Scenario | Font payload reduction | Estimated input reduction | Warm median speedup |');
+  lines.push('| --- | ---: | ---: | ---: |');
+
+  for (const scenario of report.scenarios) {
+    const allFonts = scenario.results.all_fonts;
+    const subset = scenario.results.script_subset;
+    const payloadReduction =
+      1 - subset.bytes.base64FontBytes / Math.max(1, allFonts.bytes.base64FontBytes);
+    const inputReduction =
+      1 - subset.bytes.estimatedPdfInputBytes / Math.max(1, allFonts.bytes.estimatedPdfInputBytes);
+    const speedup =
+      1 - subset.warm.totalMedianMs / Math.max(0.0001, allFonts.warm.totalMedianMs);
+
+    lines.push(
+      `| ${scenario.label} | ${toPercent(payloadReduction)} | ${toPercent(inputReduction)} | ${toPercent(speedup)} |`,
+    );
+  }
+
+  lines.push('');
+  lines.push('## Notes');
+  lines.push('');
+  lines.push('- This benchmark measures the font embedding path and estimated PDF input size.');
+  lines.push('- Estimated size uses one fixed sample image payload for repeatability.');
+  lines.push('- Real device PDF size/time still depends on actual photo content and native print engine behavior.');
+
+  return lines.join('\n');
+}
+
+async function ensureParentDir(filePath) {
+  const dir = path.dirname(filePath);
+  await fs.mkdir(dir, { recursive: true });
+}
+
+async function main() {
+  const args = parseArgs(process.argv.slice(2));
+  if (args.help) {
+    printUsage();
+    return;
+  }
+
+  const rootDir = process.cwd();
+  const fontMetaMap = await readFontMetadata(rootDir);
+
+  const sampleImageAbsolutePath = path.join(rootDir, args.sampleImagePath);
+  const sampleImageStats = await fs.stat(sampleImageAbsolutePath);
+  const sampleImageRawBytes = sampleImageStats.size;
+  const sampleImageDataUriBytes =
+    Buffer.byteLength(DATA_URI_PREFIX, 'utf8') + base64Length(sampleImageRawBytes);
+
+  const report = {
+    benchmarkedAtUtc: new Date().toISOString(),
+    environment: {
+      node: process.version,
+      platform: process.platform,
+      arch: process.arch,
+    },
+    settings: {
+      iterations: args.iterations,
+      sampleImagePath: args.sampleImagePath,
+      sampleImageRawBytes,
+      sampleImageDataUriBytes,
+      baseTemplateBytes: BASE_TEMPLATE_BYTES,
+    },
+    scenarios: [],
+  };
+
+  for (const scenario of SCENARIOS) {
+    const scenarioReport = {
+      id: scenario.id,
+      label: scenario.label,
+      localeHint: scenario.localeHint,
+      photoCount: scenario.photoCount,
+      textLength: Array.from(`${scenario.reportName}\n${scenario.comment}`).length,
+      results: {},
+    };
+
+    for (const strategyName of ['all_fonts', 'script_subset']) {
+      const runs = [];
+      for (let runIndex = 0; runIndex < args.iterations; runIndex += 1) {
+        const runResult = await benchmarkOneRun({
+          scenario,
+          strategy: strategyName,
+          fontMetaMap,
+          sampleImageDataUriBytes,
+          runIndex,
+        });
+        runs.push(runResult);
+      }
+      scenarioReport.results[strategyName] = summarizeRuns(runs);
+    }
+
+    report.scenarios.push(scenarioReport);
+  }
+
+  const markdown = buildMarkdown(report);
+
+  if (args.write) {
+    const outJsonPath = path.join(rootDir, args.outJsonPath);
+    const outMarkdownPath = path.join(rootDir, args.outMarkdownPath);
+
+    await ensureParentDir(outJsonPath);
+    await ensureParentDir(outMarkdownPath);
+
+    await fs.writeFile(outJsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8');
+    await fs.writeFile(outMarkdownPath, `${markdown}\n`, 'utf8');
+  }
+
+  process.stdout.write(`${markdown}\n`);
+}
+
+main().catch((error) => {
+  console.error(error.message);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary
- add `scripts/pdf-font-benchmark.mjs` and `pnpm pdf:font:benchmark` for repeatable PDF font embedding benchmarks
- add benchmark runbook + latest benchmark artifacts under `docs/how-to/benchmarks`
- update `ADR-0002` with Issue #72 follow-up results and explicit adopt/defer decision
- add testing guide section for running and reading benchmark outputs

## Why
- close ADR-0002 follow-ups for font optimization evaluation and performance measurement
- satisfy Issue #72 AC1/AC2/AC3 with reproducible commands, 3-scenario results, and ADR decision record

## Acceptance Criteria mapping
- AC1: benchmark runbook documented in `docs/how-to/testing.md` and `docs/how-to/pdf_font_benchmark.md`
- AC2: three scenarios (short_text/photo_heavy/multilingual) measured in `docs/how-to/benchmarks/pdf_font_benchmark.latest.md`
- AC3: adopt/defer rationale recorded in `docs/adr/ADR-0002-pdf-fonts.md`

## Validation
- `pnpm install --frozen-lockfile`
- `pnpm lint`
- `pnpm test`
- `pnpm type-check`
- `pnpm pdf:font:benchmark`
