### PR TITLE
ops: add adb install workflow and debug tooling (#105)

### DIFF
--- a/docs/how-to/android_デバッグ手順.md
+++ b/docs/how-to/android_デバッグ手順.md
@@ -1,0 +1,200 @@
+# Android デバッグ・ログ取得手順
+最終更新: 2026-02-27（JST）
+
+USB 接続した Android 実機から、WSL2 環境でクラッシュログや
+動作状況を取得・解析するための運用手順です。
+
+想定:
+- WSL2 から Windows 側の ADB を経由してデバイス通信
+- USB デバッグ有効化済み
+- `adb devices` で `device` と表示される状態
+
+---
+
+## 0. 全体像
+
+```
+[スマホ] --USB-- [Windows ADB] --WSLインターオプ-- [WSL2ターミナル]
+                                                     ├── logcat（リアルタイム監視）
+                                                     ├── pidcat（アプリ専用ログ）
+                                                     └── monitor_repolog.sh（自動保存）
+```
+
+| ツール | 用途 | コマンド例 |
+|--------|------|-----------|
+| `adb logcat` | 全ログ/クラッシュ確認 | `adb logcat -b crash -v threadtime` |
+| `pidcat` | アプリ専用・色付きログ | `pidcat com.dooooraku.repolog` |
+| `monitor_repolog.sh` | クラッシュ自動検出・保存 | `bash scripts/monitor_repolog.sh` |
+
+---
+
+## 1. 事前準備（初回のみ）
+
+### 1-1. Windows 側の ADB
+
+`android_ビルド手順.md` の事前準備で Android SDK を導入済みなら ADB も入っている。
+確認:
+
+```powershell
+# PowerShell で
+adb version
+# → Android Debug Bridge version 1.0.41 のように表示されれば OK
+```
+
+### 1-2. スマホの USB デバッグ有効化
+
+1. 設定 → 端末情報 → **ビルド番号を 7 回タップ**
+2. 設定 → 開発者向けオプション → **USB デバッグ ON**
+3. USB 接続時に「USB デバッグを許可しますか？」→ **許可**
+
+### 1-3. WSL2 から ADB 接続確認
+
+```bash
+adb devices
+# → SX3LHMA362304722  device  のように表示されれば OK
+# → "unauthorized" なら スマホ側で許可ダイアログを確認
+```
+
+### 1-4. pidcat インストール（初回のみ）
+
+```bash
+# GitHub から直接取得
+curl -sL https://raw.githubusercontent.com/JakeWharton/pidcat/master/pidcat.py \
+  -o ~/.local/bin/pidcat
+chmod +x ~/.local/bin/pidcat
+
+# shebang を python3 に修正（WSL2 は python3 のみ）
+sed -i 's|python -u|python3 -u|' ~/.local/bin/pidcat
+
+# 確認
+pidcat --help
+```
+
+---
+
+## 2. リアルタイムログ監視
+
+### 2-1. pidcat（推奨：最も簡単）
+
+```bash
+# Repolog のログだけを色付きで表示
+pidcat com.dooooraku.repolog
+```
+
+アプリが再起動しても PID を自動追跡する。Ctrl+C で停止。
+
+### 2-2. logcat 直接使用
+
+```bash
+# クラッシュログのみ
+adb logcat -b crash -v threadtime
+
+# Repolog プロセスのログだけ
+adb logcat --pid=$(adb shell pidof -s com.dooooraku.repolog) -v threadtime
+
+# エラー以上のレベルだけ
+adb logcat "*:E"
+
+# ファイルに保存しながら表示
+adb logcat -b crash -v threadtime 2>&1 | tee crash_$(date +%Y%m%d_%H%M%S).log
+```
+
+### 2-3. 自動クラッシュ監視スクリプト
+
+```bash
+# プロジェクトルートから実行
+bash scripts/monitor_repolog.sh
+
+# オプション:
+#   (引数なし)  クラッシュ・エラー自動検出＆保存（推奨）
+#   --all       全ログ表示
+#   --crash     クラッシュバッファのみ
+#   --help      ヘルプ
+```
+
+クラッシュ検出時に `docs/reference/Debug/` にログが自動保存される。
+
+---
+
+## 3. クラッシュ発生時の調査手順
+
+### 3-1. 直前のログを確認
+
+```bash
+# 最新 500 行をダンプ
+adb logcat -d -t 500 -v threadtime > recent.log
+```
+
+### 3-2. バグレポート取得（包括的）
+
+```bash
+# OS レベルの全情報を ZIP で保存（30 秒〜2 分かかる）
+adb bugreport ./repolog_bugreport.zip
+```
+
+### 3-3. メモリ・画面状態の確認
+
+```bash
+# メモリ使用量
+adb shell dumpsys meminfo com.dooooraku.repolog
+
+# アクティビティスタック
+adb shell dumpsys activity activities | grep -A 5 "repolog"
+
+# フレームレート
+adb shell dumpsys gfxinfo com.dooooraku.repolog
+```
+
+---
+
+## 4. ワイヤレス ADB（USB 不要の代替手段）
+
+Android 11 以降で利用可能。USB ケーブルなしでログ取得できる。
+
+```bash
+# 1. スマホ: 設定 → 開発者向けオプション → ワイヤレスデバッグ → ON
+# 2. 「ペア設定コードによるデバイスのペア設定」をタップ
+# 3. 表示された IP:ポート と 6 桁コードを使用
+
+adb pair 192.168.X.X:XXXXX    # ペアリング（初回のみ）
+adb connect 192.168.X.X:XXXXX  # 接続（ポート番号はペアリング時と異なる）
+
+# 以降は USB 接続時と同じコマンドが使える
+pidcat com.dooooraku.repolog
+```
+
+---
+
+## 5. ログレベル早見表
+
+| レベル | 記号 | 意味 | 色（pidcat） |
+|--------|------|------|-------------|
+| Verbose | V | 最も詳細 | 灰色 |
+| Debug | D | デバッグ情報 | 青 |
+| Info | I | 通常情報 | 緑 |
+| Warning | W | 警告 | 黄色 |
+| Error | E | エラー | 赤 |
+| Fatal | F | 致命的エラー（クラッシュ） | 赤太字 |
+
+---
+
+## 6. トラブルシューティング
+
+| 症状 | 原因 | 対処 |
+|------|------|------|
+| `adb devices` が空 | USB 接続されていない | ケーブル確認、別のポート試行 |
+| `unauthorized` | デバッグ未許可 | スマホ画面で「許可」をタップ |
+| `adb: command not found` | PATH 未設定 | `echo 'export PATH=$PATH:/mnt/c/…/platform-tools' >> ~/.bashrc` |
+| pidcat が動かない | python3 未対応 | shebang を `python3` に修正 |
+| ログが流れない | アプリ未起動 | スマホで Repolog を起動 |
+| `more than one device` | 複数デバイス接続 | `adb -s <SERIAL> logcat` で指定 |
+
+---
+
+## 参考: ログ保存先
+
+| 種類 | 保存先 |
+|------|--------|
+| 自動保存（monitor_repolog.sh） | `docs/reference/Debug/` |
+| 手動保存 | プロジェクトルート（任意） |
+| バグレポート | 指定したパス |

--- a/eas.json
+++ b/eas.json
@@ -1,0 +1,42 @@
+{
+  "cli": {
+    "version": ">= 18.0.0",
+    "appVersionSource": "remote"
+  },
+  "build": {
+    "development": {
+      "developmentClient": true,
+      "distribution": "internal",
+      "environment": "development",
+      "android": {
+        "buildType": "apk",
+        "withoutCredentials": true
+      }
+    },
+    "preview-cloud-apk": {
+      "distribution": "internal",
+      "environment": "preview",
+      "android": {
+        "buildType": "apk"
+      }
+    },
+    "preview-local-apk": {
+      "distribution": "internal",
+      "environment": "preview",
+      "android": {
+        "buildType": "apk",
+        "withoutCredentials": true
+      }
+    },
+    "production": {
+      "environment": "production",
+      "autoIncrement": true,
+      "android": {
+        "buildType": "app-bundle"
+      }
+    }
+  },
+  "submit": {
+    "production": {}
+  }
+}

--- a/package.json
+++ b/package.json
@@ -17,7 +17,11 @@
     "ump:consent:check": "node scripts/ump-consent-check.mjs",
     "pdf:font:benchmark": "node --expose-gc scripts/pdf-font-benchmark.mjs",
     "prebuild": "expo prebuild",
-    "build:android": "expo prebuild --platform android && cd android && ./gradlew bundleRelease"
+    "build:android": "expo prebuild --platform android && cd android && ./gradlew bundleRelease",
+    "build:android:apk:local": "npx eas-cli@latest build -p android --profile preview-local-apk --local --output dist/repolog-preview-local.apk",
+    "build:android:apk:cloud": "npx eas-cli@latest build -p android --profile preview-cloud-apk",
+    "build:android:aab:cloud": "npx eas-cli@latest build -p android --profile production",
+    "install:device": "adb install -r \"$(wslpath -w dist/repolog-preview-local.apk)\""
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",

--- a/scripts/monitor_repolog.sh
+++ b/scripts/monitor_repolog.sh
@@ -1,0 +1,202 @@
+#!/bin/bash
+# =============================================================================
+# monitor_repolog.sh
+# =============================================================================
+# 役割: Repologアプリのクラッシュ・エラーをリアルタイム監視し、
+#       異常検出時に自動でログファイルを保存するスクリプト
+#
+# 使い方:
+#   bash scripts/monitor_repolog.sh          # 通常の監視（クラッシュ+エラー）
+#   bash scripts/monitor_repolog.sh --all    # 全ログを表示（verbose）
+#   bash scripts/monitor_repolog.sh --crash  # クラッシュログのみ
+#
+# 前提条件:
+#   - adb が PATH に通っていること（WSL2からWindows ADB経由でOK）
+#   - スマホがUSB接続され、USBデバッグが許可されていること
+#   - adb devices で "device" と表示されること（"unauthorized" はNG）
+#
+# 停止方法: Ctrl+C
+# =============================================================================
+
+set -euo pipefail
+
+# --- 設定 -------------------------------------------------------------------
+# PACKAGE: 監視対象のAndroidアプリのパッケージ名
+PACKAGE="com.dooooraku.repolog"
+
+# LOG_DIR: クラッシュログの保存先ディレクトリ
+# $(dirname "$0") = このスクリプトが置かれているフォルダ
+# /../docs/reference/Debug = プロジェクトのdocs配下に保存
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+LOG_DIR="$PROJECT_ROOT/docs/reference/Debug"
+
+# --- ヘルパー関数 -----------------------------------------------------------
+
+# 色付き出力用の定数
+RED='\033[0;31m'
+YELLOW='\033[1;33m'
+GREEN='\033[0;32m'
+CYAN='\033[0;36m'
+NC='\033[0m' # No Color（色リセット）
+
+# info: 情報メッセージを表示（緑色）
+info() {
+  echo -e "${GREEN}[INFO]${NC} $*"
+}
+
+# warn: 警告メッセージを表示（黄色）
+warn() {
+  echo -e "${YELLOW}[WARN]${NC} $*"
+}
+
+# error: エラーメッセージを表示（赤色）
+error() {
+  echo -e "${RED}[ERROR]${NC} $*"
+}
+
+# --- 前提条件チェック -------------------------------------------------------
+
+# adb コマンドが使えるかチェック
+if ! command -v adb &>/dev/null; then
+  error "adb が見つかりません"
+  echo "  Windows側: winget install Google.PlatformTools"
+  echo "  WSL2側:     echo 'export PATH=\$PATH:/mnt/c/platform-tools' >> ~/.bashrc"
+  exit 1
+fi
+
+# デバイスが接続されているかチェック
+DEVICE_STATUS=$(adb devices 2>/dev/null | grep -v "List" | grep -v "^$" | head -1)
+if [ -z "$DEVICE_STATUS" ]; then
+  error "Androidデバイスが接続されていません"
+  echo "  1. USBケーブルでスマホを接続してください"
+  echo "  2. スマホの「開発者向けオプション」→「USBデバッグ」をONにしてください"
+  echo "  3. 「USBデバッグを許可しますか？」で「許可」をタップしてください"
+  exit 1
+fi
+
+if echo "$DEVICE_STATUS" | grep -q "unauthorized"; then
+  error "USBデバッグが許可されていません"
+  echo "  スマホの画面に「USBデバッグを許可しますか？」と表示されているはずです"
+  echo "  「許可」をタップしてください"
+  exit 1
+fi
+
+DEVICE_ID=$(echo "$DEVICE_STATUS" | awk '{print $1}')
+info "デバイス検出: $DEVICE_ID"
+
+# --- モード選択 -------------------------------------------------------------
+
+MODE="monitor"  # デフォルト: 監視モード（クラッシュ・エラーをキャプチャ）
+
+case "${1:-}" in
+  --all)
+    MODE="all"
+    info "モード: 全ログ表示"
+    ;;
+  --crash)
+    MODE="crash"
+    info "モード: クラッシュログのみ"
+    ;;
+  --help|-h)
+    echo "使い方: $0 [--all|--crash|--help]"
+    echo ""
+    echo "  (引数なし)  クラッシュ・エラー監視モード（推奨）"
+    echo "  --all       全ログ表示（verbose、大量のログが流れます）"
+    echo "  --crash     クラッシュバッファのみ表示"
+    echo "  --help      このヘルプを表示"
+    exit 0
+    ;;
+esac
+
+# --- ログ保存ディレクトリ作成 -----------------------------------------------
+
+mkdir -p "$LOG_DIR"
+
+# --- メイン処理 -------------------------------------------------------------
+
+# Ctrl+C で終了する際のクリーンアップ
+cleanup() {
+  echo ""
+  info "監視を終了しました"
+  info "保存済みログ: $LOG_DIR/"
+  exit 0
+}
+trap cleanup INT TERM
+
+echo ""
+echo "=============================================="
+echo "  Repolog クラッシュ監視"
+echo "=============================================="
+echo "  パッケージ: $PACKAGE"
+echo "  デバイス:   $DEVICE_ID"
+echo "  ログ保存先: $LOG_DIR/"
+echo "  停止: Ctrl+C"
+echo "=============================================="
+echo ""
+
+case "$MODE" in
+  all)
+    # 全ログ: Repologのプロセスに絞って全レベル表示
+    # --pid= でRepologプロセスのログだけに絞る
+    APP_PID=$(adb shell pidof -s "$PACKAGE" 2>/dev/null || echo "")
+    if [ -n "$APP_PID" ]; then
+      info "Repolog PID: $APP_PID"
+      adb logcat --pid="$APP_PID" -v threadtime
+    else
+      warn "Repologが起動していません。全ログから $PACKAGE をフィルタします"
+      adb logcat -v threadtime | grep --line-buffered -i "$PACKAGE"
+    fi
+    ;;
+
+  crash)
+    # クラッシュバッファのみ表示
+    # -b crash = クラッシュ専用バッファ
+    # -v threadtime = 日時・スレッド情報付き
+    info "クラッシュバッファを監視中..."
+    adb logcat -b crash -v threadtime
+    ;;
+
+  monitor)
+    # 監視モード: クラッシュを検出して自動保存
+    info "クラッシュ・エラー監視を開始..."
+
+    # ログバッファをクリア（古いログを除外）
+    adb logcat -c 2>/dev/null || true
+
+    CRASH_COUNT=0
+
+    # crash + main バッファを監視
+    adb logcat -b crash,main -v threadtime 2>/dev/null | while IFS= read -r line; do
+      # Repologに関連するログ行かチェック
+      if echo "$line" | grep -qi "$PACKAGE"; then
+        # クラッシュ・エラーのキーワードを含むかチェック
+        if echo "$line" | grep -qi "FATAL\|Exception\|Error\|ANR\|CRASH\|died\|killed"; then
+          CRASH_COUNT=$((CRASH_COUNT + 1))
+          TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+
+          echo ""
+          echo -e "${RED}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!${NC}"
+          echo -e "${RED}  クラッシュ/エラー検出 #${CRASH_COUNT}${NC}"
+          echo -e "${RED}  時刻: $(date '+%Y-%m-%d %H:%M:%S')${NC}"
+          echo -e "${RED}!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!${NC}"
+          echo ""
+          echo "$line"
+          echo ""
+
+          # クラッシュ行を専用ファイルに保存
+          echo "=== Crash #${CRASH_COUNT} at $TIMESTAMP ===" >> "$LOG_DIR/crash_${TIMESTAMP}.log"
+          echo "$line" >> "$LOG_DIR/crash_${TIMESTAMP}.log"
+
+          # 現在のログバッファ全体をダンプ保存（クラッシュ前後の文脈がわかる）
+          adb logcat -d -v threadtime > "$LOG_DIR/full_${TIMESTAMP}.log" 2>/dev/null
+
+          info "ログ保存完了:"
+          info "  クラッシュ: $LOG_DIR/crash_${TIMESTAMP}.log"
+          info "  全体ログ: $LOG_DIR/full_${TIMESTAMP}.log"
+          echo ""
+        fi
+      fi
+    done
+    ;;
+esac


### PR DESCRIPTION
## Summary

- `adb install` による APK 直接インストールをプライマリ手順に変更
- デバッグ手順ドキュメント新設（logcat、pidcat、クラッシュ監視）
- `pnpm install:device` ワンコマンドスクリプト追加
- `monitor_repolog.sh` クラッシュ自動検出スクリプト追加
- `eas.json` をバージョン管理に追加

## 背景と検証結果

従来の Google Drive 手動転送（3〜5分/回）を `adb install`（約20秒）に置き換える。
以下のWSL2環境で動作検証済み:

- `wslpath -w` によるパス変換: ✅
- `adb install -r` による上書きインストール: ✅（176MB APK）
- `adb shell am start` によるアプリ起動: ✅
- `adb logcat` によるクラッシュログ取得: ✅

## 専門家レビュー議論

**モバイルアプリ開発者:** Google Drive 転送は1回3〜5分、1日10回で50分のロス。`adb install` なら約20秒で10倍以上の改善。確実に導入すべき。

**WSL2インフラエンジニア:** `wslpath -w` によるパス変換が `adb.exe` で正常動作することを実機検証済み。`\\wsl.localhost\Ubuntu\...` パスをadb.exeが受け付ける。ミラードネットワーキング環境で安定。

**QAエンジニア:** Google Drive 手動転送はフォールバックとして残すべき（USB接続できない場面もある）。ドキュメント上「推奨」と「代替」を明確に区別している点は良い。

**テスト担当者（ユーザー視点）:** `pnpm install:device` が一番わかりやすい。`pnpm build:android:apk:local && pnpm install:device` でビルドからインストールまで一括できるのは便利。

**セキュリティ視点:** `debug.keystore` はリポジトリに含まれるが、これはAndroid標準のデバッグ署名で公知のパスワード（`android`）を使用するため問題ない。本番署名はEAS管理。

## 変更ファイル

| ファイル | 変更内容 |
|---------|---------|
| `docs/how-to/android_ビルド手順.md` | 5章を `adb install` 主軸に改訂 |
| `docs/how-to/android_デバッグ手順.md` | 新規: logcat/pidcat/ワイヤレスADB手順 |
| `package.json` | `install:device` スクリプト追加 |
| `scripts/monitor_repolog.sh` | 新規: クラッシュ自動監視スクリプト |
| `eas.json` | バージョン管理に追加 |

## Test plan

- [x] `pnpm install:device` で APK がスマホにインストールされる
- [x] `adb install -r` で上書きインストールが成功する
- [x] `adb shell am start` でアプリが起動する
- [x] `adb logcat -b crash` でクラッシュログが取得できる
- [x] `pnpm lint` / `pnpm test` / `pnpm type-check` 全パス
- [ ] `bash scripts/monitor_repolog.sh` でクラッシュ監視が動作する

Closes #105

🤖 Generated with [Claude Code](https://claude.com/claude-code)