### PR TITLE
fix: add TamaguiProvider to root layout (#108)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,8 +1,10 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { TamaguiProvider } from 'tamagui';
 import 'react-native-reanimated';
 
+import tamaguiConfig from '@/tamagui.config';
 import { useColorScheme } from '@/hooks/use-color-scheme';
 
 export const unstable_settings = {
@@ -13,17 +15,19 @@ export default function RootLayout() {
   const colorScheme = useColorScheme();
 
   return (
-    <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-      <Stack>
-        <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-        <Stack.Screen name="reports/[id]" options={{ headerShown: false }} />
-        <Stack.Screen name="reports/[id]/pdf" options={{ headerShown: false }} />
-        <Stack.Screen name="pro" options={{ headerShown: false }} />
-        <Stack.Screen name="backup" options={{ headerShown: false }} />
-        <Stack.Screen name="settings" options={{ headerShown: false }} />
-        <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
-      </Stack>
-      <StatusBar style="auto" />
-    </ThemeProvider>
+    <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+        <Stack>
+          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="reports/[id]" options={{ headerShown: false }} />
+          <Stack.Screen name="reports/[id]/pdf" options={{ headerShown: false }} />
+          <Stack.Screen name="pro" options={{ headerShown: false }} />
+          <Stack.Screen name="backup" options={{ headerShown: false }} />
+          <Stack.Screen name="settings" options={{ headerShown: false }} />
+          <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
+        </Stack>
+        <StatusBar style="auto" />
+      </ThemeProvider>
+    </TamaguiProvider>
   );
 }


### PR DESCRIPTION
## Summary

- `app/_layout.tsx` に `TamaguiProvider` を追加し、アプリ起動時のクラッシュを修正

## 原因

`@tamagui/lucide-icons`（Search, Settings, Sun, Cloud 等）は内部で `useThemeState()` を呼び出し、
Tamagui のテーマコンテキストを必要とする。`TamaguiProvider` がコンポーネントツリーに存在しなかったため、
ホーム画面でアイコンがレンダリングされる瞬間に `"Can't find Tamagui configuration"` エラーでクラッシュしていた。

## 修正内容

```diff
+ import { TamaguiProvider } from 'tamagui';
+ import tamaguiConfig from '@/tamagui.config';

  export default function RootLayout() {
    return (
+     <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
        <ThemeProvider ...>
          <Stack>...</Stack>
        </ThemeProvider>
+     </TamaguiProvider>
    );
  }
```

## 検証方法

1. dev build APK を `adb install` でインストール
2. Metro bundler を起動 (`npx expo start --dev-client`)
3. アプリを起動し、赤いエラー画面が出ず、ホーム画面が表示されることを確認

## Test plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm test` — 51/51 passed
- [x] `pnpm type-check` — clean
- [ ] 実機で起動確認（Metro接続で検証予定）

Closes #108

🤖 Generated with [Claude Code](https://claude.com/claude-code)