### PR TITLE
fix: resolve 6 bugs from device testing (SDK54 legacy + editor UX)

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -19,6 +19,7 @@ export default function RootLayout() {
       <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
         <Stack>
           <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+          <Stack.Screen name="reports/new" options={{ headerShown: false }} />
           <Stack.Screen name="reports/[id]" options={{ headerShown: false }} />
           <Stack.Screen name="reports/[id]/pdf" options={{ headerShown: false }} />
           <Stack.Screen name="pro" options={{ headerShown: false }} />

--- a/src/core/i18n/locales/ja.ts
+++ b/src/core/i18n/locales/ja.ts
@@ -244,6 +244,7 @@ const dict = {
   photoPermissionDenied: '写真へのアクセス許可が必要です',
   photoAddFailed: '写真を追加できませんでした',
   photoEmpty: '写真がまだありません。',
+  tagInputPlaceholder: 'タグを追加（カンマ・改行で区切り）...',
   photoReorderHint: '長押しで並べ替え、×で削除できます。',
   photoReorderFailed: '写真の並び順を保存できませんでした。',
   photoDeleteConfirmTitle: '写真を削除しますか？',

--- a/src/features/backup/backupService.ts
+++ b/src/features/backup/backupService.ts
@@ -1,7 +1,7 @@
 import { Platform } from 'react-native';
 import Constants from 'expo-constants';
 import * as DocumentPicker from 'expo-document-picker';
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import * as Sharing from 'expo-sharing';
 import { unzip, zip } from 'react-native-zip-archive';
 
@@ -85,11 +85,9 @@ export class BackupError extends Error {
   }
 }
 
-const getDocumentDirectory = () =>
-  FileSystem.Paths?.document?.uri ?? (FileSystem as unknown as { documentDirectory?: string }).documentDirectory;
+const getDocumentDirectory = () => FileSystem.documentDirectory;
 
-const getCacheDirectory = () =>
-  FileSystem.Paths?.cache?.uri ?? (FileSystem as unknown as { cacheDirectory?: string }).cacheDirectory;
+const getCacheDirectory = () => FileSystem.cacheDirectory;
 
 const stripFileScheme = (uri: string) => uri.replace(/^file:\/\//, '');
 

--- a/src/features/pdf/pdfFonts.ts
+++ b/src/features/pdf/pdfFonts.ts
@@ -1,6 +1,6 @@
 import Constants from 'expo-constants';
 import { Asset } from 'expo-asset';
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 
 import { selectPdfFontKeys } from './pdfFontSelection';
 

--- a/src/features/pdf/pdfTemplate.ts
+++ b/src/features/pdf/pdfTemplate.ts
@@ -1,4 +1,4 @@
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 
 import type { Photo, Report } from '@/src/types/models';
 import { buildPdfFontCss, pdfFontStack } from './pdfFonts';

--- a/src/features/reports/ReportEditorScreen.tsx
+++ b/src/features/reports/ReportEditorScreen.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { useRouter } from 'expo-router';
 import { Image } from 'expo-image';
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import DraggableFlatList, { type RenderItemParams } from 'react-native-draggable-flatlist';
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
@@ -324,7 +324,7 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
         return;
       }
 
-      const baseRoot = FileSystem.Paths?.cache?.uri ?? FileSystem.Paths?.document?.uri;
+      const baseRoot = FileSystem.cacheDirectory ?? FileSystem.documentDirectory;
       if (!baseRoot) {
         throw new Error('FileSystem path unavailable for E2E seed photos.');
       }
@@ -496,14 +496,15 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
         return;
       }
       const payload = buildPayload();
-      if (reportId) {
-        await updateReport({ id: reportId, ...payload });
+      const existingId = report?.id ?? reportId;
+      if (existingId) {
+        await updateReport({ id: existingId, ...payload });
       } else {
         const created = await createReport(payload);
         setReport(created);
         setCreatedAt(created.createdAt);
       }
-      Alert.alert(t.save);
+      router.back();
     } catch {
       Alert.alert(t.errorSaveFailed);
     } finally {

--- a/src/services/photoService.ts
+++ b/src/services/photoService.ts
@@ -1,5 +1,5 @@
 import * as ImagePicker from 'expo-image-picker';
-import * as FileSystem from 'expo-file-system';
+import * as FileSystem from 'expo-file-system/legacy';
 import * as ImageManipulator from 'expo-image-manipulator';
 
 import type { Photo } from '@/src/types/models';
@@ -18,8 +18,7 @@ type AddPhotoResult = {
   reason?: 'permission' | 'error';
 };
 
-const getDocumentDirectory = () =>
-  FileSystem.Paths?.document?.uri ?? (FileSystem as unknown as { documentDirectory?: string }).documentDirectory;
+const getDocumentDirectory = () => FileSystem.documentDirectory;
 
 const ensureReportPhotoDir = async (reportId: string) => {
   const documentDirectory = getDocumentDirectory();
@@ -200,7 +199,7 @@ export async function addPhotosFromCamera(
   }
 
   const result = await ImagePicker.launchCameraAsync({
-    mediaTypes: ImagePicker.MediaTypeOptions.Images,
+    mediaTypes: ['images'],
     allowsEditing: false,
     quality: 1,
   });
@@ -222,7 +221,7 @@ export async function addPhotosFromLibrary(
   }
 
   const result = await ImagePicker.launchImageLibraryAsync({
-    mediaTypes: ImagePicker.MediaTypeOptions.Images,
+    mediaTypes: ['images'],
     allowsMultipleSelection: true,
     selectionLimit: 0,
     quality: 1,


### PR DESCRIPTION
## Summary

Closes #110

初回実デバイステスト（dev build + Metro接続）で発見された6つのバグを一括修正。

### P0 修正（クリティカル）
- **カメラ写真保存失敗**: `expo-file-system` → `expo-file-system/legacy` に切り替え（5ファイル）。SDK 54でデフォルトexportが新APIに変更され、旧API（`makeDirectoryAsync`等）が存在しなくなっていた
- **PDF作成失敗**: 同上。`pdfFonts.ts:61` の `readAsStringAsync` と `pdfTemplate.ts:71` の `readAsStringAsync` を復旧
- **レポート重複作成**: `handleSave` が `reportId`(prop) のみチェックしていたのを `report?.id ?? reportId` に修正。`ensureReport()` で既に作成済みのレポートを正しく認識

### P1 修正（重要）
- **保存後Home遷移なし**: `Alert.alert(t.save)` → `router.back()` に変更
- **ヘッダー重複**: `_layout.tsx` に `reports/new` の `Stack.Screen` 追加（`headerShown: false`）

### P2 修正（改善）
- **タグプレースホルダー英語表示**: `ja.ts` に `tagInputPlaceholder` の日本語翻訳追加
- **ImagePicker非推奨警告**: `MediaTypeOptions.Images` → `['images']` に更新

### 変更ファイル（7ファイル）
- `app/_layout.tsx` — Stack.Screen追加
- `src/services/photoService.ts` — legacy import + MediaTypeOptions修正
- `src/features/pdf/pdfFonts.ts` — legacy import
- `src/features/pdf/pdfTemplate.ts` — legacy import
- `src/features/backup/backupService.ts` — legacy import + ヘルパー簡素化
- `src/features/reports/ReportEditorScreen.tsx` — legacy import + 重複作成修正 + 遷移修正
- `src/core/i18n/locales/ja.ts` — tagInputPlaceholder翻訳追加

## Test plan

- [ ] lint 0 errors ✅
- [ ] jest 51/51 pass ✅
- [ ] type-check clean ✅
- [ ] dev buildでカメラ撮影→写真保存が動作すること
- [ ] dev buildでPDF作成が動作すること
- [ ] 新規レポート保存で重複が発生しないこと
- [ ] 保存後にHome画面に遷移すること
- [ ] reports/new画面でヘッダーが1つだけ表示されること
- [ ] タグ入力欄のプレースホルダーが日本語表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)