### PR TITLE
fix: add GestureHandlerRootView to root layout

### DIFF
--- a/app/_layout.tsx
+++ b/app/_layout.tsx
@@ -1,6 +1,7 @@
 import { DarkTheme, DefaultTheme, ThemeProvider } from '@react-navigation/native';
 import { Stack } from 'expo-router';
 import { StatusBar } from 'expo-status-bar';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 import { TamaguiProvider } from 'tamagui';
 import 'react-native-reanimated';
 
@@ -15,20 +16,22 @@ export default function RootLayout() {
   const colorScheme = useColorScheme();
 
   return (
-    <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
-      <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
-        <Stack>
-          <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
-          <Stack.Screen name="reports/new" options={{ headerShown: false }} />
-          <Stack.Screen name="reports/[id]" options={{ headerShown: false }} />
-          <Stack.Screen name="reports/[id]/pdf" options={{ headerShown: false }} />
-          <Stack.Screen name="pro" options={{ headerShown: false }} />
-          <Stack.Screen name="backup" options={{ headerShown: false }} />
-          <Stack.Screen name="settings" options={{ headerShown: false }} />
-          <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
-        </Stack>
-        <StatusBar style="auto" />
-      </ThemeProvider>
-    </TamaguiProvider>
+    <GestureHandlerRootView style={{ flex: 1 }}>
+      <TamaguiProvider config={tamaguiConfig} defaultTheme="dark">
+        <ThemeProvider value={colorScheme === 'dark' ? DarkTheme : DefaultTheme}>
+          <Stack>
+            <Stack.Screen name="(tabs)" options={{ headerShown: false }} />
+            <Stack.Screen name="reports/new" options={{ headerShown: false }} />
+            <Stack.Screen name="reports/[id]" options={{ headerShown: false }} />
+            <Stack.Screen name="reports/[id]/pdf" options={{ headerShown: false }} />
+            <Stack.Screen name="pro" options={{ headerShown: false }} />
+            <Stack.Screen name="backup" options={{ headerShown: false }} />
+            <Stack.Screen name="settings" options={{ headerShown: false }} />
+            <Stack.Screen name="modal" options={{ presentation: 'modal', title: 'Modal' }} />
+          </Stack>
+          <StatusBar style="auto" />
+        </ThemeProvider>
+      </TamaguiProvider>
+    </GestureHandlerRootView>
   );
 }


### PR DESCRIPTION
## Summary

Closes #110 (follow-up)

`DraggableFlatList`（写真の並べ替えUI）が内部で`react-native-gesture-handler`の`GestureDetector`を使用しており、`GestureHandlerRootView`が祖先に必要。

PR #111 でファイルシステム修正により写真保存が動作するようになったことで、`DraggableFlatList`が初めてレンダリングされ、このエラーが露呈した。

### 変更内容
- `app/_layout.tsx`: `GestureHandlerRootView` でアプリ全体をラップ

## Test plan
- [ ] lint: 0 errors ✅
- [ ] test: 51/51 pass ✅
- [ ] type-check: clean ✅
- [ ] カメラ撮影→写真保存→写真一覧が正常に表示されること
- [ ] 写真の長押しドラッグで並べ替えが動作すること

🤖 Generated with [Claude Code](https://claude.com/claude-code)