### PR TITLE
fix: enable Android 13+ predictive back gesture (#122)

### DIFF
--- a/app.json
+++ b/app.json
@@ -21,7 +21,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "edgeToEdgeEnabled": true,
-      "predictiveBackGestureEnabled": false
+      "predictiveBackGestureEnabled": true
     },
     "web": {
       "output": "static",


### PR DESCRIPTION
## Summary
- Enable `predictiveBackGestureEnabled: true` in `app.json` for Android 13+ predictive back animation

## Background
Log analysis of debug sessions on Pixel 8a (Android 14) showed repeated warnings:
```
WindowOnBackDispatcher: OnBackInvokedCallback is not enabled for the application
```
This appeared in 2 out of 6 debug sessions (2026-02-28).

## Changes
| File | Change |
|------|--------|
| `app.json` | `predictiveBackGestureEnabled`: `false` → `true` |

## Risk assessment
- **Low risk**: Expo Router handles back navigation internally; this setting enables the system animation overlay
- **Requires APK rebuild**: Native config change (not a JS-only change)

## Test plan
- [ ] APK rebuild: `pnpm build:android:apk:local`
- [ ] Install on device: `pnpm install:device`
- [ ] Verify back gesture shows preview animation on: Home → Report Editor → back
- [ ] Verify back gesture works on: Settings → back
- [ ] Verify back gesture works on: PDF Preview → back
- [ ] Verify logcat no longer shows `OnBackInvokedCallback` warning

Closes #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)