### PR TITLE
ops: add debug session management script

### DIFF
--- a/docs/how-to/development/android_debug.md
+++ b/docs/how-to/development/android_debug.md
@@ -25,6 +25,7 @@ USB 接続した Android 実機から、WSL2 環境でクラッシュログや
 | `adb logcat` | 全ログ/クラッシュ確認 | `adb logcat -b crash -v threadtime` |
 | `pidcat` | アプリ専用・色付きログ | `pidcat com.dooooraku.repolog` |
 | `monitor_repolog.sh` | クラッシュ自動検出・保存 | `bash scripts/monitor_repolog.sh` |
+| `debug_session.sh` | セッション一括管理 | `bash scripts/debug_session.sh start` |
 
 ---
 
@@ -217,11 +218,61 @@ scrcpy --record=demo.mp4 --max-fps=30
 
 ---
 
+## 8. デバッグセッション（一括管理）
+
+`debug_session.sh` を使うと、ログ・スクリーンショット・録画・メモリ情報を
+1 つのセッションフォルダに自動収集できる。
+
+### 8-1. 基本的な流れ
+
+```bash
+# 1. セッション開始（logcat + 画面録画を自動起動）
+bash scripts/debug_session.sh start
+
+# 2. スマホでアプリを操作する
+
+# 3. セッション終了（全成果物を自動収集）
+bash scripts/debug_session.sh stop
+```
+
+### 8-2. オプション
+
+```bash
+# 録画なしで開始（logcat + スクリーンショットのみ）
+bash scripts/debug_session.sh start --no-record
+
+# セッション状態の確認
+bash scripts/debug_session.sh status
+```
+
+### 8-3. 成果物
+
+stop 時に `docs/reference/Debug/session_YYYYMMDD_HHMMSS/` に自動生成:
+
+| ファイル | 内容 |
+|---------|------|
+| `before.png` | 操作前スクリーンショット |
+| `after.png` | 操作後スクリーンショット |
+| `logcat.log` | セッション中の全ログ |
+| `recording.mp4` | 画面録画（`--no-record` 時は省略） |
+| `meminfo.txt` | メモリ使用量 |
+| `summary.md` | セッション概要（エラー抽出付き） |
+
+### 8-4. Claude Code との連携
+
+```bash
+# セッション停止後、Claude Code にサマリーを読ませて分析
+# → summary.md のエラー抽出 + before/after 画像の差分確認
+```
+
+---
+
 ## 参考: ログ・画像保存先
 
 | 種類 | 保存先 |
 |------|--------|
 | 自動保存（monitor_repolog.sh） | `docs/reference/Debug/` |
+| デバッグセッション（debug_session.sh） | `docs/reference/Debug/session_YYYYMMDD_HHMMSS/` |
 | スクリーンショット | `docs/reference/Debug/` または任意 |
 | 画面録画（scrcpy） | コマンド引数で指定 |
 | 手動保存 | プロジェクトルート（任意） |

--- a/scripts/debug_session.sh
+++ b/scripts/debug_session.sh
@@ -1,0 +1,377 @@
+#!/bin/bash
+# =============================================================================
+# debug_session.sh
+# =============================================================================
+# 役割: デバッグセッションの一括管理。
+#       start → 操作 → stop の流れで、ログ・画像・動画・メモリ情報を
+#       1つのセッションフォルダに自動収集する。
+#
+# 使い方:
+#   bash scripts/debug_session.sh start        # セッション開始
+#   bash scripts/debug_session.sh stop         # セッション終了・収集
+#   bash scripts/debug_session.sh status       # 稼働状態の確認
+#   bash scripts/debug_session.sh start --no-record  # 録画なしで開始
+#
+# 前提条件:
+#   - adb が PATH に通っていること（WSL2 ラッパーでOK）
+#   - スマホがUSB接続され、USBデバッグが許可されていること
+#
+# セッション成果物（stop 時に自動生成）:
+#   docs/reference/Debug/session_YYYYMMDD_HHMMSS/
+#   ├── before.png       操作前スクリーンショット
+#   ├── after.png        操作後スクリーンショット
+#   ├── logcat.log       セッション中の全ログ
+#   ├── recording.mp4    画面録画（--no-record 時は省略）
+#   ├── meminfo.txt      メモリ使用量
+#   └── summary.md       セッション概要（Claude Code 分析用）
+# =============================================================================
+
+set -uo pipefail
+
+# --- 定数 -------------------------------------------------------------------
+PACKAGE="com.dooooraku.repolog"
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+DEBUG_DIR="$PROJECT_ROOT/docs/reference/Debug"
+SESSION_FILE="/tmp/repolog_debug_session"
+DEVICE_RECORDING_PATH="/sdcard/repolog_debug_recording.mp4"
+
+# --- 色定義 -----------------------------------------------------------------
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+info()  { echo -e "${GREEN}[INFO]${NC} $*"; }
+warn()  { echo -e "${YELLOW}[WARN]${NC} $*"; }
+error() { echo -e "${RED}[ERROR]${NC} $*"; }
+
+# --- 共通: デバイスチェック ---------------------------------------------------
+check_device() {
+  if ! command -v adb &>/dev/null; then
+    error "adb が見つかりません"
+    exit 1
+  fi
+
+  local status
+  status=$(adb devices 2>/dev/null | grep -v "List" | grep -v "^$" | head -1)
+  if [ -z "$status" ]; then
+    error "デバイスが接続されていません"
+    exit 1
+  fi
+  if echo "$status" | grep -q "unauthorized"; then
+    error "USBデバッグが許可されていません"
+    exit 1
+  fi
+  echo "$status" | awk '{print $1}'
+}
+
+# --- 共通: スクリーンショット -------------------------------------------------
+take_screenshot() {
+  local output_path="$1"
+  env -u ADB_SERVER_SOCKET adb exec-out screencap -p > "$output_path" 2>/dev/null
+  if [ -s "$output_path" ]; then
+    info "スクリーンショット: $output_path"
+  else
+    warn "スクリーンショット取得失敗: $output_path"
+    rm -f "$output_path"
+  fi
+}
+
+# =============================================================================
+# start: セッション開始
+# =============================================================================
+cmd_start() {
+  local do_record=true
+  for arg in "$@"; do
+    case "$arg" in
+      --no-record) do_record=false ;;
+    esac
+  done
+
+  # 既存セッションのチェック
+  if [ -f "$SESSION_FILE" ]; then
+    warn "既にセッションが実行中です"
+    cat "$SESSION_FILE"
+    echo ""
+    warn "先に stop するか、不要なら $SESSION_FILE を削除してください"
+    exit 1
+  fi
+
+  local device_id
+  device_id=$(check_device)
+
+  # セッションフォルダ作成
+  local timestamp
+  timestamp=$(date +%Y%m%d_%H%M%S)
+  local session_dir="$DEBUG_DIR/session_${timestamp}"
+  mkdir -p "$session_dir"
+
+  info "セッション開始: session_${timestamp}"
+  info "デバイス: $device_id"
+  info "保存先: $session_dir/"
+
+  # ログバッファクリア
+  adb logcat -c 2>/dev/null || true
+
+  # 初期スクリーンショット
+  take_screenshot "$session_dir/before.png"
+
+  # logcat バックグラウンド開始
+  env -u ADB_SERVER_SOCKET adb logcat -v threadtime > "$session_dir/logcat.log" 2>/dev/null &
+  local logcat_pid=$!
+  info "logcat 開始 (PID: $logcat_pid)"
+
+  # 画面録画バックグラウンド開始
+  local record_pid=""
+  if [ "$do_record" = true ]; then
+    adb shell screenrecord --time-limit 180 "$DEVICE_RECORDING_PATH" &
+    record_pid=$!
+    info "画面録画 開始 (PID: $record_pid, 上限: 3分)"
+  else
+    info "画面録画: スキップ (--no-record)"
+  fi
+
+  # アプリの PID を記録
+  local app_pid
+  app_pid=$(adb shell pidof -s "$PACKAGE" 2>/dev/null || echo "")
+
+  # セッション情報をファイルに保存
+  cat > "$SESSION_FILE" <<EOF
+SESSION_DIR="$session_dir"
+SESSION_TIMESTAMP="$timestamp"
+DEVICE_ID="$device_id"
+LOGCAT_PID="$logcat_pid"
+RECORD_PID="${record_pid:-}"
+APP_PID="${app_pid:-unknown}"
+DO_RECORD="$do_record"
+START_TIME="$(date +%s)"
+START_TIME_HUMAN="$(date '+%Y-%m-%d %H:%M:%S')"
+EOF
+
+  echo ""
+  echo -e "${BOLD}=============================================${NC}"
+  echo -e "${BOLD}  Repolog デバッグセッション${NC}"
+  echo -e "${BOLD}=============================================${NC}"
+  echo -e "  セッション: session_${timestamp}"
+  echo -e "  デバイス:   $device_id"
+  echo -e "  アプリPID:  ${app_pid:-未起動}"
+  echo -e "  logcat:     稼働中 (PID: $logcat_pid)"
+  if [ "$do_record" = true ]; then
+    echo -e "  画面録画:   稼働中 (上限3分)"
+  else
+    echo -e "  画面録画:   OFF"
+  fi
+  echo -e "  保存先:     $session_dir/"
+  echo -e "${BOLD}=============================================${NC}"
+  echo ""
+  echo -e "${CYAN}  アプリを操作してください。${NC}"
+  echo -e "${CYAN}  終わったら: bash scripts/debug_session.sh stop${NC}"
+  echo ""
+}
+
+# =============================================================================
+# stop: セッション終了・成果物収集
+# =============================================================================
+cmd_stop() {
+  if [ ! -f "$SESSION_FILE" ]; then
+    error "実行中のセッションがありません"
+    exit 1
+  fi
+
+  # セッション情報を読み込む
+  # shellcheck disable=SC1090
+  source "$SESSION_FILE"
+
+  local device_id
+  device_id=$(check_device 2>/dev/null || echo "disconnected")
+
+  info "セッション停止: session_${SESSION_TIMESTAMP}"
+
+  # logcat 停止
+  if kill -0 "$LOGCAT_PID" 2>/dev/null; then
+    kill "$LOGCAT_PID" 2>/dev/null || true
+    wait "$LOGCAT_PID" 2>/dev/null || true
+    info "logcat 停止"
+  else
+    warn "logcat は既に停止していました"
+  fi
+
+  # 画面録画 停止
+  if [ "$DO_RECORD" = true ] && [ -n "${RECORD_PID:-}" ]; then
+    if kill -0 "$RECORD_PID" 2>/dev/null; then
+      kill "$RECORD_PID" 2>/dev/null || true
+      wait "$RECORD_PID" 2>/dev/null || true
+    fi
+    # デバイス上の録画プロセスも停止
+    adb shell pkill -2 screenrecord 2>/dev/null || true
+    sleep 2
+
+    # 録画ファイルをデバイスからPCに転送
+    if adb shell ls "$DEVICE_RECORDING_PATH" &>/dev/null; then
+      adb pull "$DEVICE_RECORDING_PATH" "$SESSION_DIR/recording.mp4" 2>/dev/null
+      adb shell rm -f "$DEVICE_RECORDING_PATH" 2>/dev/null || true
+      info "画面録画 取得完了: recording.mp4"
+    else
+      warn "画面録画ファイルが見つかりません（録画時間が短すぎた可能性）"
+    fi
+  fi
+
+  # 最終スクリーンショット
+  if [ "$device_id" != "disconnected" ]; then
+    take_screenshot "$SESSION_DIR/after.png"
+
+    # メモリ情報取得
+    adb shell dumpsys meminfo "$PACKAGE" > "$SESSION_DIR/meminfo.txt" 2>/dev/null || true
+    info "メモリ情報: meminfo.txt"
+  fi
+
+  # ログの行数をカウント
+  local log_lines=0
+  local error_lines=0
+  if [ -f "$SESSION_DIR/logcat.log" ]; then
+    log_lines=$(wc -l < "$SESSION_DIR/logcat.log")
+    error_lines=$(grep -ci "error\|exception\|fatal\|crash" "$SESSION_DIR/logcat.log" || echo "0")
+  fi
+
+  # セッション経過時間
+  local end_time
+  end_time=$(date +%s)
+  local duration=$(( end_time - START_TIME ))
+  local duration_min=$(( duration / 60 ))
+  local duration_sec=$(( duration % 60 ))
+
+  # サマリーファイル作成
+  cat > "$SESSION_DIR/summary.md" <<SUMMARY
+# デバッグセッション: session_${SESSION_TIMESTAMP}
+
+## 概要
+| 項目 | 値 |
+|------|-----|
+| 開始時刻 | ${START_TIME_HUMAN} |
+| 終了時刻 | $(date '+%Y-%m-%d %H:%M:%S') |
+| 所要時間 | ${duration_min}分${duration_sec}秒 |
+| デバイス | ${DEVICE_ID} |
+| アプリPID | ${APP_PID} |
+
+## 成果物
+| ファイル | 説明 |
+|---------|------|
+| before.png | 操作前スクリーンショット |
+| after.png | 操作後スクリーンショット |
+| logcat.log | 全ログ (${log_lines} 行) |
+| recording.mp4 | 画面録画 |
+| meminfo.txt | メモリ使用量 |
+
+## ログ概要
+- 総行数: ${log_lines}
+- エラー関連行: ${error_lines}
+
+## エラー行の抽出（先頭20件）
+\`\`\`
+$(grep -i "error\|exception\|fatal\|crash" "$SESSION_DIR/logcat.log" 2>/dev/null | head -20 || echo "(なし)")
+\`\`\`
+SUMMARY
+
+  info "サマリー: summary.md"
+
+  # セッションファイル削除
+  rm -f "$SESSION_FILE"
+
+  echo ""
+  echo -e "${BOLD}=============================================${NC}"
+  echo -e "${BOLD}  セッション完了${NC}"
+  echo -e "${BOLD}=============================================${NC}"
+  echo -e "  所要時間:   ${duration_min}分${duration_sec}秒"
+  echo -e "  ログ行数:   ${log_lines}"
+  echo -e "  エラー行:   ${error_lines}"
+  echo -e "  保存先:     $SESSION_DIR/"
+  echo -e "${BOLD}=============================================${NC}"
+  echo ""
+  echo -e "${CYAN}  成果物一覧:${NC}"
+  ls -lh "$SESSION_DIR/" 2>/dev/null | tail -n +2
+  echo ""
+}
+
+# =============================================================================
+# status: セッション状態の確認
+# =============================================================================
+cmd_status() {
+  if [ ! -f "$SESSION_FILE" ]; then
+    info "実行中のセッションはありません"
+    exit 0
+  fi
+
+  # shellcheck disable=SC1090
+  source "$SESSION_FILE"
+
+  local now
+  now=$(date +%s)
+  local elapsed=$(( now - START_TIME ))
+  local elapsed_min=$(( elapsed / 60 ))
+  local elapsed_sec=$(( elapsed % 60 ))
+
+  local logcat_status="停止"
+  if kill -0 "$LOGCAT_PID" 2>/dev/null; then
+    logcat_status="稼働中"
+  fi
+
+  local record_status="OFF"
+  if [ "$DO_RECORD" = true ] && [ -n "${RECORD_PID:-}" ]; then
+    if kill -0 "$RECORD_PID" 2>/dev/null; then
+      record_status="稼働中"
+    else
+      record_status="停止（3分経過 or 終了）"
+    fi
+  fi
+
+  local log_lines=0
+  if [ -f "$SESSION_DIR/logcat.log" ]; then
+    log_lines=$(wc -l < "$SESSION_DIR/logcat.log")
+  fi
+
+  echo ""
+  echo -e "${BOLD}  デバッグセッション状態${NC}"
+  echo -e "  セッション: session_${SESSION_TIMESTAMP}"
+  echo -e "  経過時間:   ${elapsed_min}分${elapsed_sec}秒"
+  echo -e "  logcat:     ${logcat_status} (${log_lines} 行)"
+  echo -e "  画面録画:   ${record_status}"
+  echo -e "  保存先:     $SESSION_DIR/"
+  echo ""
+}
+
+# =============================================================================
+# ヘルプ
+# =============================================================================
+cmd_help() {
+  echo "使い方: $0 <command> [options]"
+  echo ""
+  echo "コマンド:"
+  echo "  start [--no-record]  セッション開始（ログ収集・録画開始）"
+  echo "  stop                 セッション終了（成果物を収集・保存）"
+  echo "  status               セッションの稼働状態を表示"
+  echo "  help                 このヘルプを表示"
+  echo ""
+  echo "典型的な使い方:"
+  echo "  1. bash scripts/debug_session.sh start"
+  echo "  2. （アプリを操作する）"
+  echo "  3. bash scripts/debug_session.sh stop"
+  echo "  4. docs/reference/Debug/session_*/ を確認"
+}
+
+# =============================================================================
+# メイン
+# =============================================================================
+case "${1:-help}" in
+  start)  shift; cmd_start "$@" ;;
+  stop)   cmd_stop ;;
+  status) cmd_status ;;
+  help|--help|-h) cmd_help ;;
+  *)
+    error "不明なコマンド: $1"
+    cmd_help
+    exit 1
+    ;;
+esac


### PR DESCRIPTION
## 概要 / Overview
デバッグセッションの一括管理スクリプト `debug_session.sh` を追加。
`start` → アプリ操作 → `stop` の流れで、ログ・スクリーンショット・録画・メモリ情報を1つのセッションフォルダに自動収集する。

## 種別 / Type
- [x] 運用改善 (Ops)
- [ ] 新機能 / 変更 / 修正 / リファクタ / ドキュメント / テスト

## 関連 Issue / Linked Issues
Closes #131

## 目的と背景 / Purpose & Context
デバッグ時に logcat・screencap・screenrecord・meminfo を個別に実行する手間を省き、
1コマンドで開始・停止できるセッション管理を実現する。
`summary.md` を自動生成することで、Claude Code による分析の入力としても使える。

## 変更内容 / Changes Made
### 新規ファイル
- `scripts/debug_session.sh`: セッション管理スクリプト（378行）
  - `start [--no-record]`: デバイスチェック → logcat開始 → 録画開始 → 初期スクショ
  - `stop`: プロセス停止 → 最終スクショ → 録画回収 → meminfo → summary.md生成
  - `status`: 稼働状態・経過時間・ログ行数の表示
  - `help`: 使い方表示

### 変更ファイル
- `docs/how-to/development/android_debug.md`:
  - ツール一覧に `debug_session.sh` を追加
  - セクション8「デバッグセッション（一括管理）」を追加
  - 保存先一覧にセッションフォルダを追加

## 受け入れ条件 / Acceptance Criteria
- [x] `bash scripts/debug_session.sh help` でヘルプが表示される
- [x] `start --no-record` → `status` → `stop` の一連の流れが動作する
- [x] stop 時に before.png, after.png, logcat.log, meminfo.txt, summary.md が生成される
- [x] summary.md にエラー行の抽出が含まれる
- [x] 既存テスト 51/51 パス、lint エラーなし

## 影響範囲 / Impact Scope
- 既存コードへの変更なし（新規スクリプト追加 + ドキュメント更新のみ）
- アプリのビルド・動作に影響なし

## データ / Data & Compatibility
- セッション状態: `/tmp/repolog_debug_session`（一時ファイル）
- 成果物: `docs/reference/Debug/session_YYYYMMDD_HHMMSS/`（.gitignore 対象）

## テスト / Testing
- [x] `start --no-record` → `status` → `stop` を実機で実行確認
- [x] before.png / after.png の取得確認
- [x] logcat.log の収集確認（205行）
- [x] summary.md のエラー抽出確認（12件）
- [x] meminfo.txt の取得確認
- [x] セッション重複起動のエラー検出確認
- [x] `pnpm test` 51/51 パス
- [x] `npx expo lint` パス

## ドキュメント / Documentation
- `docs/how-to/development/android_debug.md` にセクション8を追加済み

## リスクと復旧 / Risk & Rollback
- リスク: 低（新規スクリプト追加のみ）
- 復旧: スクリプトを削除するだけ

## Done の定義 / Definition of Done
- [x] コードレビュー完了
- [x] テストパス
- [x] ドキュメント更新済み


🤖 Generated with [Claude Code](https://claude.com/claude-code)