### PR TITLE
fix: restore base64 data URI for PDF fonts (revert file:// regression)

### DIFF
--- a/src/features/pdf/pdfFonts.ts
+++ b/src/features/pdf/pdfFonts.ts
@@ -1,5 +1,6 @@
 import Constants from 'expo-constants';
 import { Asset } from 'expo-asset';
+import * as FileSystem from 'expo-file-system/legacy';
 
 import { selectPdfFontKeys } from './pdfFontSelection';
 
@@ -46,36 +47,27 @@ const fontAssets = [
 type FontAsset = (typeof fontAssets)[number];
 type FontAssetKey = FontAsset['key'];
 
-const fontUriCache = new Map<FontAsset['source'], string>();
+const fontCache = new Map<FontAsset['source'], string>();
 
-/**
- * Return a file:// URI pointing to the font on disk.
- *
- * Previous implementation read the whole font file into memory, base64-encoded
- * it, and embedded it as a data-URI in the HTML string.  For CJK variable
- * fonts this produced 10-17 MB of base64 **per font**, pushing the WebView
- * renderer past Android's 256 MB heap limit (OOM).
- *
- * The new approach references the font directly via its local file path.
- * Android's WebView can resolve `file://` URIs, so the font is loaded from
- * disk on demand instead of being buffered in the JS heap.  This eliminates
- * the ~15 MB base64 overhead for a typical Japanese-locale PDF.
- */
-async function loadFontFileUri(source: FontAsset['source']) {
-  const cached = fontUriCache.get(source);
+async function loadFontDataUri(source: FontAsset['source']) {
+  const cached = fontCache.get(source);
   if (cached) return cached;
 
   const asset = Asset.fromModule(source);
   if (!asset.localUri) {
     await asset.downloadAsync();
   }
-  const fileUri = asset.localUri ?? asset.uri;
-  fontUriCache.set(source, fileUri);
-  return fileUri;
+  const uri = asset.localUri ?? asset.uri;
+  const base64 = await FileSystem.readAsStringAsync(uri, {
+    encoding: 'base64',
+  });
+  const dataUri = `data:font/ttf;base64,${base64}`;
+  fontCache.set(source, dataUri);
+  return dataUri;
 }
 
 export function clearFontCache() {
-  fontUriCache.clear();
+  fontCache.clear();
 }
 
 function toBooleanFlag(value: unknown): boolean {
@@ -107,8 +99,8 @@ export async function buildPdfFontCss(options: BuildPdfFontCssOptions = {}) {
   const selectedFonts = fontAssets.filter((font) => selectedKeys.has(font.key));
   const rules = await Promise.all(
     selectedFonts.map(async (font) => {
-      const uri = await loadFontFileUri(font.source);
-      return `@font-face {\n  font-family: '${font.family}';\n  src: url('${uri}') format('truetype');\n  font-weight: 100 900;\n  font-style: normal;\n}`;
+      const dataUri = await loadFontDataUri(font.source);
+      return `@font-face {\n  font-family: '${font.family}';\n  src: url('${dataUri}') format('truetype');\n  font-weight: 100 900;\n  font-style: normal;\n}`;
     }),
   );
 


### PR DESCRIPTION
## Summary
- PR #118 re-introduced the `file://` URI approach for PDF font loading
- PR #126 had already reverted this because `file://` URIs are blocked by expo-print's WebView on Android
- This commit restores the working base64 data URI approach

## Test plan
- [ ] Verify PDF generation works on Android with Japanese locale (CJK fonts render correctly)
- [ ] Verify no OOM crash occurs during PDF preview

🤖 Generated with [Claude Code](https://claude.ai/claude-code)