### PR TITLE
feat: add accessibilityLabel to 5 major buttons (#141)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -271,6 +271,8 @@ export default function HomeScreen() {
           <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>Repolog</Text>
           <Pressable
             testID="e2e_open_settings"
+            accessibilityLabel={t.settings}
+            accessibilityRole="button"
             onPress={() => router.push('/settings')}
             hitSlop={TOUCH_HIT_SLOP}
             style={styles.headerIconButton}>
@@ -346,6 +348,8 @@ export default function HomeScreen() {
 
         <Pressable
           testID="e2e_home_create_report_fab"
+          accessibilityLabel={t.homeCreateReport}
+          accessibilityRole="button"
           onPress={() => router.push('/reports/new')}
           hitSlop={TOUCH_HIT_SLOP}
           style={[styles.fabButton, { backgroundColor: colors.primaryBg }]}>

--- a/src/core/i18n/locales/de.ts
+++ b/src/core/i18n/locales/de.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: 'Noch keine Tags.',
   photoDeletedNotice: 'Foto entfernt.',
   undoAction: 'Rückgängig',
+  a11yGoBack: 'Zurück',
 };
 
 export default dict;

--- a/src/core/i18n/locales/en.ts
+++ b/src/core/i18n/locales/en.ts
@@ -93,6 +93,9 @@ const baseEn = {
 
   // --- Icon Categories & Labels ---
 
+  // --- Accessibility ---
+  a11yGoBack: 'Go back',
+
   // --- Misc / Errors ---
   errorLoadFailed: 'Failed to load data.',
   errorSaveFailed: 'Failed to save.',

--- a/src/core/i18n/locales/es.ts
+++ b/src/core/i18n/locales/es.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: 'No hay etiquetas aún.',
   photoDeletedNotice: 'Foto eliminada.',
   undoAction: 'Deshacer',
+  a11yGoBack: 'Volver',
 };
 
 export default dict;

--- a/src/core/i18n/locales/fr.ts
+++ b/src/core/i18n/locales/fr.ts
@@ -180,6 +180,7 @@ const dict = {
   tagsEmpty: 'Aucun tag pour le moment.',
   photoDeletedNotice: 'Photo supprimée.',
   undoAction: 'Annuler',
+  a11yGoBack: 'Retour',
 };
 
 export default dict;

--- a/src/core/i18n/locales/hi.ts
+++ b/src/core/i18n/locales/hi.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: 'अभी कोई टैग नहीं।',
   photoDeletedNotice: 'फ़ोटो हटाई गई।',
   undoAction: 'पूर्ववत करें',
+  a11yGoBack: 'वापस जाएँ',
 };
 
 export default dict;

--- a/src/core/i18n/locales/id.ts
+++ b/src/core/i18n/locales/id.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: 'Belum ada tag.',
   photoDeletedNotice: 'Foto dihapus.',
   undoAction: 'Urungkan',
+  a11yGoBack: 'Kembali',
 };
 
 export default dict;

--- a/src/core/i18n/locales/it.ts
+++ b/src/core/i18n/locales/it.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: 'Nessun tag.',
   photoDeletedNotice: 'Foto rimossa.',
   undoAction: 'Annulla',
+  a11yGoBack: 'Indietro',
 };
 
 export default dict;

--- a/src/core/i18n/locales/ja.ts
+++ b/src/core/i18n/locales/ja.ts
@@ -174,6 +174,7 @@ const dict = {
   pdfPhotos: '枚',
   pdfPages: 'ページ',
   pdfComment: 'コメント',
+  a11yGoBack: '戻る',
 };
 
 export default dict;

--- a/src/core/i18n/locales/ko.ts
+++ b/src/core/i18n/locales/ko.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: '태그가 없습니다.',
   photoDeletedNotice: '사진이 삭제되었습니다.',
   undoAction: '실행 취소',
+  a11yGoBack: '뒤로 가기',
 };
 
 export default dict;

--- a/src/core/i18n/locales/nl.ts
+++ b/src/core/i18n/locales/nl.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: 'Nog geen tags.',
   photoDeletedNotice: 'Foto verwijderd.',
   undoAction: 'Ongedaan maken',
+  a11yGoBack: 'Terug',
 };
 
 export default dict;

--- a/src/core/i18n/locales/pl.ts
+++ b/src/core/i18n/locales/pl.ts
@@ -177,6 +177,7 @@ const dict = {
   backupSchemaMismatchBody: 'Ta kopia używa innej wersji schematu.',
   backupUnsupportedTitle: 'Nieobsługiwane',
   backupUnsupportedBody: 'Kopia zapasowa nie jest obsługiwana na tym urządzeniu.',
+  a11yGoBack: 'Wróć',
 };
 
 export default dict;

--- a/src/core/i18n/locales/pt.ts
+++ b/src/core/i18n/locales/pt.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: 'Nenhuma tag ainda.',
   photoDeletedNotice: 'Foto removida.',
   undoAction: 'Desfazer',
+  a11yGoBack: 'Voltar',
 };
 
 export default dict;

--- a/src/core/i18n/locales/ru.ts
+++ b/src/core/i18n/locales/ru.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: 'Тегов пока нет.',
   photoDeletedNotice: 'Фото удалено.',
   undoAction: 'Отменить',
+  a11yGoBack: 'Назад',
 };
 
 export default dict;

--- a/src/core/i18n/locales/sv.ts
+++ b/src/core/i18n/locales/sv.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: 'Inga taggar ännu.',
   photoDeletedNotice: 'Foto borttaget.',
   undoAction: 'Ångra',
+  a11yGoBack: 'Gå tillbaka',
 };
 
 export default dict;

--- a/src/core/i18n/locales/th.ts
+++ b/src/core/i18n/locales/th.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: 'ยังไม่มีแท็ก',
   photoDeletedNotice: 'ลบรูปภาพแล้ว',
   undoAction: 'เลิกทำ',
+  a11yGoBack: 'ย้อนกลับ',
 };
 
 export default dict;

--- a/src/core/i18n/locales/tr.ts
+++ b/src/core/i18n/locales/tr.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: 'Henüz etiket yok.',
   photoDeletedNotice: 'Fotoğraf kaldırıldı.',
   undoAction: 'Geri al',
+  a11yGoBack: 'Geri dön',
 };
 
 export default dict;

--- a/src/core/i18n/locales/vi.ts
+++ b/src/core/i18n/locales/vi.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: 'Chưa có thẻ nào.',
   photoDeletedNotice: 'Đã xóa ảnh.',
   undoAction: 'Hoàn tác',
+  a11yGoBack: 'Quay lại',
 };
 
 export default dict;

--- a/src/core/i18n/locales/zhHans.ts
+++ b/src/core/i18n/locales/zhHans.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: '暂无标签。',
   photoDeletedNotice: '照片已删除。',
   undoAction: '撤销',
+  a11yGoBack: '返回',
 };
 
 export default dict;

--- a/src/core/i18n/locales/zhHant.ts
+++ b/src/core/i18n/locales/zhHant.ts
@@ -153,6 +153,7 @@ const dict = {
   tagsEmpty: '尚無標籤。',
   photoDeletedNotice: '照片已刪除。',
   undoAction: '復原',
+  a11yGoBack: '返回',
 };
 
 export default dict;

--- a/src/features/reports/ReportEditorScreen.tsx
+++ b/src/features/reports/ReportEditorScreen.tsx
@@ -709,14 +709,14 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
       <View style={[styles.screen, { backgroundColor: colors.screenBg }]} testID="e2e_report_editor_screen">
         <View style={[styles.header, { borderBottomColor: colors.borderDefault, backgroundColor: colors.surfaceBg }]}>
           <View style={styles.headerLeft}>
-            <Pressable testID="e2e_report_back" onPress={handleBack} style={styles.backButton} hitSlop={TOUCH_HIT_SLOP}>
+            <Pressable testID="e2e_report_back" accessibilityLabel={t.a11yGoBack} accessibilityRole="button" onPress={handleBack} style={styles.backButton} hitSlop={TOUCH_HIT_SLOP}>
               <ArrowLeft size={18} color={colors.textPrimary} strokeWidth={ICON_STROKE_WIDTH} />
             </Pressable>
             <Text style={[styles.headerTitle, { color: colors.textPrimary }]} numberOfLines={1}>
               {t.reportEditorTitle}
             </Text>
           </View>
-          <Pressable testID="e2e_report_pdf_preview" onPress={handlePreviewPdf} style={[styles.pdfButton, { backgroundColor: colors.primaryBg }]} hitSlop={TOUCH_HIT_SLOP}>
+          <Pressable testID="e2e_report_pdf_preview" accessibilityLabel={t.pdfPreviewTitle} accessibilityRole="button" onPress={handlePreviewPdf} style={[styles.pdfButton, { backgroundColor: colors.primaryBg }]} hitSlop={TOUCH_HIT_SLOP}>
             <FileText size={15} color={colors.textOnPrimary} strokeWidth={ICON_STROKE_WIDTH} />
             <Text style={[styles.pdfButtonText, { color: colors.textOnPrimary }]}>PDF</Text>
           </Pressable>
@@ -933,7 +933,7 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
         </ScrollView>
 
         <View style={[styles.footerBar, { borderTopColor: colors.borderDefault, backgroundColor: colors.surfaceBg }]}>
-          <Pressable onPress={handleSave} style={[styles.saveButton, { backgroundColor: colors.primaryBg }, saving && styles.disabledButton]} disabled={saving} hitSlop={TOUCH_HIT_SLOP}>
+          <Pressable accessibilityLabel={t.save} accessibilityRole="button" onPress={handleSave} style={[styles.saveButton, { backgroundColor: colors.primaryBg }, saving && styles.disabledButton]} disabled={saving} hitSlop={TOUCH_HIT_SLOP}>
             {saving ? <ActivityIndicator color={colors.primaryText} /> : <Text style={[styles.saveButtonText, { color: colors.textOnPrimary }]}>{t.save}</Text>}
           </Pressable>
         </View>

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -103,7 +103,7 @@ export default function SettingsScreen() {
     <SafeAreaView style={[styles.safeArea, { backgroundColor: colors.screenBgAlt }]} edges={['top']}>
       <ScrollView contentContainerStyle={[styles.container, { backgroundColor: colors.screenBgAlt }]} testID="e2e_settings_screen">
         <View style={styles.headerRow}>
-          <Pressable testID="e2e_back_home" onPress={() => router.back()} style={[styles.backButton, { borderColor: colors.borderMedium, backgroundColor: colors.surfaceBg }]}>
+          <Pressable testID="e2e_back_home" accessibilityLabel={t.a11yGoBack} accessibilityRole="button" onPress={() => router.back()} style={[styles.backButton, { borderColor: colors.borderMedium, backgroundColor: colors.surfaceBg }]}>
             <Text style={[styles.backText, { color: colors.textSecondary }]}>{'‹'}</Text>
           </Pressable>
           <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t.settings}</Text>


### PR DESCRIPTION
## Summary
- 主要5ボタンに accessibilityLabel + accessibilityRole を追加
- スクリーンリーダー対応の基盤を整備（v1.0 最小スコープ）

## Type
feat

## Related links
- Closes #141

## Purpose (Why)
Google Play 品質ガイドラインではアクセシビリティが推奨項目。アイコンのみのボタンにラベルがないとスクリーンリーダーで操作不能。

## Changes (What)
1. `app/(tabs)/index.tsx`: FAB + Settings アイコンに `accessibilityLabel` + `accessibilityRole="button"`
2. `ReportEditorScreen.tsx`: Back / PDF / Save ボタンに同上
3. `SettingsScreen.tsx`: Back ボタンに同上
4. 全 19 locale に `a11yGoBack` キー追加

## Acceptance Criteria
- [x] 主要5ボタンに accessibilityLabel が設定されている
- [x] accessibilityRole="button" が設定されている
- [ ] フォントスケール 1.5x でレイアウトが崩れないことを確認（手動テスト）
- [ ] WCAG AA 色コントラスト比 4.5:1 以上を確認（手動テスト）

## Impact
- 影響画面: Home, Report Editor, Settings
- Free/Pro: Both
- i18n: 19 言語に `a11yGoBack` 追加

## Testing
### Automated
- [x] `pnpm lint` — pass
- [x] `pnpm type-check` — pass
- [x] `pnpm test` — 12 suites, 51 tests pass
- [x] `pnpm i18n:check` — 181 used, 0 unused, 0 missing

### Manual
- [ ] TalkBack (Android) でラベルが正しく読み上げられること
- [ ] フォントスケール 1.5x でレイアウト確認
- [ ] ダーク/ライト両モードでコントラスト確認

## Risk and rollback
- Risk: Low — props 追加のみ、既存動作に影響なし
- Rollback: revert commit

## DoD
- [x] CI が全て成功
- [x] i18n キーが 19 言語に追加済み
- [x] 既存テストが全てパス

🤖 Generated with [Claude Code](https://claude.com/claude-code)