### PR TITLE
test: add 3 Maestro E2E flows for theme, PDF, backup (#138)

### DIFF
--- a/app/reports/[id]/pdf.tsx
+++ b/app/reports/[id]/pdf.tsx
@@ -220,7 +220,7 @@ export default function PdfPreviewScreen() {
   }
 
   return (
-    <View style={[styles.container, { backgroundColor: colors.screenBgAlt }]}>
+    <View testID="e2e_pdf_preview_screen" style={[styles.container, { backgroundColor: colors.screenBgAlt }]}>
       <Text style={[styles.title, { color: colors.textPrimary }]}>{t.pdfPreviewTitle}</Text>
       <View style={styles.row}>
         <Pressable
@@ -253,7 +253,7 @@ export default function PdfPreviewScreen() {
           trustAllCerts={false}
         />
       )}
-      <Pressable style={[styles.exportButton, { backgroundColor: colors.primaryBg }]} onPress={handleExport} disabled={exporting}>
+      <Pressable testID="e2e_pdf_export" style={[styles.exportButton, { backgroundColor: colors.primaryBg }]} onPress={handleExport} disabled={exporting}>
         {exporting ? (
           <ActivityIndicator color={colors.primaryText} />
         ) : (

--- a/maestro/flows/backup-screen-reach.yml
+++ b/maestro/flows/backup-screen-reach.yml
@@ -1,0 +1,53 @@
+appId: "com.dooooraku.repolog"
+name: "E2E - backup screen reach"
+tags:
+  - e2e
+  - settings
+
+---
+- launchApp:
+    clearState: true
+    label: "クリーン起動"
+
+- extendedWaitUntil:
+    visible:
+      id: "e2e_home_screen"
+    timeout: 60000
+    label: "Homeの初期描画を待機"
+
+- tapOn:
+    id: "e2e_open_settings"
+    label: "設定を開く"
+
+- assertVisible:
+    id: "e2e_settings_screen"
+    label: "設定画面を確認"
+
+- scrollUntilVisible:
+    element:
+      id: "e2e_open_backup"
+    direction: DOWN
+    timeout: 10000
+    label: "バックアップボタンまでスクロール"
+
+- tapOn:
+    id: "e2e_open_backup"
+    label: "バックアップ画面を開く"
+
+- extendedWaitUntil:
+    visible:
+      id: "e2e_backup_screen"
+    timeout: 30000
+    label: "バックアップ画面を待機"
+
+- assertVisible:
+    id: "e2e_backup_screen"
+    label: "バックアップ画面に到達"
+
+- tapOn:
+    id: "e2e_backup_back"
+    label: "設定へ戻る"
+
+- assertVisible:
+    id: "e2e_settings_screen"
+    label: "設定画面へ復帰"

--- a/maestro/flows/pdf-preview-reach.yml
+++ b/maestro/flows/pdf-preview-reach.yml
@@ -1,0 +1,44 @@
+appId: "com.dooooraku.repolog"
+name: "E2E - PDF preview reach"
+tags:
+  - e2e
+  - pdf
+
+---
+- launchApp:
+    clearState: true
+    label: "クリーン起動"
+
+- extendedWaitUntil:
+    visible:
+      id: "e2e_home_screen"
+    timeout: 60000
+    label: "Homeの初期描画を待機"
+
+- tapOn:
+    id: "e2e_home_create_report"
+    label: "新規レポートを作成"
+
+- extendedWaitUntil:
+    visible:
+      id: "e2e_report_editor_screen"
+    timeout: 30000
+    label: "編集画面を待機"
+
+- tapOn:
+    id: "e2e_report_pdf_preview"
+    label: "PDFプレビューを開く"
+
+- extendedWaitUntil:
+    visible:
+      id: "e2e_pdf_preview_screen"
+    timeout: 30000
+    label: "PDFプレビュー画面を待機"
+
+- assertVisible:
+    id: "e2e_pdf_preview_screen"
+    label: "PDFプレビューに到達"
+
+- assertVisible:
+    id: "e2e_pdf_export"
+    label: "PDF出力ボタンが表示される"

--- a/maestro/flows/settings-theme-toggle.yml
+++ b/maestro/flows/settings-theme-toggle.yml
@@ -1,0 +1,64 @@
+appId: "com.dooooraku.repolog"
+name: "E2E - theme toggle cycle"
+tags:
+  - e2e
+  - settings
+
+---
+- launchApp:
+    clearState: true
+    label: "クリーン起動"
+
+- extendedWaitUntil:
+    visible:
+      id: "e2e_home_screen"
+    timeout: 60000
+    label: "Homeの初期描画を待機"
+
+- tapOn:
+    id: "e2e_open_settings"
+    label: "設定を開く"
+
+- assertVisible:
+    id: "e2e_settings_screen"
+    label: "設定画面を確認"
+
+# System → Light
+- tapOn:
+    id: "e2e_theme_light"
+    label: "Lightモードに切替"
+
+- assertVisible:
+    id: "e2e_theme_light"
+    label: "Lightボタンが見える"
+
+# Light → Dark
+- tapOn:
+    id: "e2e_theme_dark"
+    label: "Darkモードに切替"
+
+- assertVisible:
+    id: "e2e_theme_dark"
+    label: "Darkボタンが見える"
+
+# Dark → System
+- tapOn:
+    id: "e2e_theme_system"
+    label: "Systemモードに切替"
+
+- assertVisible:
+    id: "e2e_theme_system"
+    label: "Systemボタンが見える"
+
+# System → Light (元に戻す)
+- tapOn:
+    id: "e2e_theme_light"
+    label: "Lightに戻す"
+
+- tapOn:
+    id: "e2e_back_home"
+    label: "Homeに戻る"
+
+- assertVisible:
+    id: "e2e_home_screen"
+    label: "Home画面に復帰"

--- a/src/features/backup/BackupScreen.tsx
+++ b/src/features/backup/BackupScreen.tsx
@@ -80,9 +80,9 @@ export default function BackupScreen() {
   };
 
   return (
-    <ScrollView contentContainerStyle={[styles.container, { backgroundColor: colors.screenBgAlt }]}>
+    <ScrollView testID="e2e_backup_screen" contentContainerStyle={[styles.container, { backgroundColor: colors.screenBgAlt }]}>
       <View style={styles.headerRow}>
-        <Pressable onPress={() => router.back()} style={[styles.backButton, { borderColor: colors.borderMedium, backgroundColor: colors.surfaceBg }]}>
+        <Pressable testID="e2e_backup_back" onPress={() => router.back()} style={[styles.backButton, { borderColor: colors.borderMedium, backgroundColor: colors.surfaceBg }]}>
           <Text style={[styles.backText, { color: colors.textSecondary }]}>{'‹'}</Text>
         </Pressable>
         <Text style={[styles.headerTitle, { color: colors.textPrimary }]}>{t.backupTitle}</Text>

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -217,7 +217,7 @@ export default function SettingsScreen() {
         <View style={[styles.section, { backgroundColor: colors.surfaceBg, borderColor: colors.borderLight }]}>
           <Text style={[styles.sectionTitle, { color: colors.textPrimary }]}>{t.settingsSectionBackup}</Text>
           <Text style={[styles.sectionBody, { color: colors.textMuted }]}>{t.settingsBackupDesc}</Text>
-          <Pressable onPress={() => router.push('/backup')} style={[styles.secondaryButton, { borderColor: colors.borderMedium, backgroundColor: colors.surfaceBg }]}>
+          <Pressable testID="e2e_open_backup" onPress={() => router.push('/backup')} style={[styles.secondaryButton, { borderColor: colors.borderMedium, backgroundColor: colors.surfaceBg }]}>
             <Text style={[styles.secondaryButtonText, { color: colors.textPrimary }]}>{t.settingsBackupOpen}</Text>
           </Pressable>
         </View>


### PR DESCRIPTION
## Summary
- テーマ切替・PDF到達・バックアップ画面到達の Maestro E2E フローを追加
- 不足していた testID を PDF プレビュー・バックアップ画面に追加

## Type
test

## Related links
- Closes #138
- Depends on: #137 (System theme testID), #141 (a11y labels)

## Purpose (Why)
重要機能（ダークモード切替、PDF到達、バックアップ画面遷移）に E2E カバレッジがなかった。

## Changes (What)

### testID 追加
| File | testID |
|------|--------|
| `app/reports/[id]/pdf.tsx` | `e2e_pdf_preview_screen`, `e2e_pdf_export` |
| `src/features/backup/BackupScreen.tsx` | `e2e_backup_screen`, `e2e_backup_back` |
| `src/features/settings/SettingsScreen.tsx` | `e2e_open_backup` |

### 新規 Maestro フロー
1. `settings-theme-toggle.yml` — Light → Dark → System → Light のサイクル
2. `pdf-preview-reach.yml` — 新規レポート → PDF プレビュー到達
3. `backup-screen-reach.yml` — 設定 → バックアップ画面 → 設定復帰

## Acceptance Criteria
- [x] 3 新規フローが既存パターン（appId, id: targeting, launchApp with clearState）に準拠
- [x] 必要な testID が全て追加済み
- [x] `pnpm verify` 通過
- [ ] 手動: 3 フローが実機で `maestro test` 成功

## Testing
### Automated
- [x] `pnpm verify` — all 4 gates pass

### Manual (requires physical device)
- [ ] `maestro test maestro/flows/settings-theme-toggle.yml`
- [ ] `maestro test maestro/flows/pdf-preview-reach.yml`
- [ ] `maestro test maestro/flows/backup-screen-reach.yml`

## Risk and rollback
- Risk: Low — testID 追加と YAML ファイルのみ
- Rollback: revert commit

## DoD
- [x] CI が全て成功
- [x] 既存 smoke.yml の安定性に影響なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)