### PR TITLE
docs: add dev build workflow script and documentation (#106)

### DIFF
--- a/docs/how-to/development/android_debug.md
+++ b/docs/how-to/development/android_debug.md
@@ -267,6 +267,48 @@ stop 時に `docs/reference/Debug/session_YYYYMMDD_HHMMSS/` に自動生成:
 
 ---
 
+## 9. Dev Build + Metro ワークフロー
+
+日常の開発では **Dev Build**（expo-dev-client）を使い、ホットリロードで高速に開発します。
+
+### 9-1. ワンコマンド起動
+
+```bash
+# ADB 確認 → ポートフォワーディング → Metro 起動を一括実行
+bash scripts/dev-start.sh
+
+# キャッシュクリアして起動
+bash scripts/dev-start.sh --clean
+
+# カスタムポート
+bash scripts/dev-start.sh --port 8082
+```
+
+### 9-2. Dev Build APK のビルドとインストール
+
+```bash
+# EAS Cloud でビルド
+npx eas-cli@latest build -p android --profile development
+
+# ローカルビルド
+npx eas-cli@latest build -p android --profile development --local --output dist/repolog-dev.apk
+
+# デバイスにインストール
+env -u ADB_SERVER_SOCKET adb install -r dist/repolog-dev.apk
+```
+
+### 9-3. Dev Build vs Preview Build
+
+詳しくは `docs/how-to/development/dev_vs_preview_builds.md` を参照。
+
+| | Dev Build | Preview Build |
+|---|---|---|
+| ホットリロード | あり | なし |
+| 1 サイクル | 1〜3 秒 | 10〜20 分 |
+| 本番に近い動作 | いいえ | はい |
+
+---
+
 ## 参考: ログ・画像保存先
 
 | 種類 | 保存先 |

--- a/docs/how-to/development/dev_vs_preview_builds.md
+++ b/docs/how-to/development/dev_vs_preview_builds.md
@@ -1,0 +1,102 @@
+# Dev Build vs Preview Build 使い分けガイド
+
+最終更新: 2026-03-03（JST）
+
+## 概要
+
+Repolog には 2 種類のビルドがあり、目的に応じて使い分けます。
+
+| | Dev Build | Preview Build |
+|---|---|---|
+| **用途** | 日常の開発・デバッグ | リリース前の動作確認 |
+| **EAS Profile** | `development` | `preview-local-apk` |
+| **Metro bundler** | 必要（JS は PC から配信） | 不要（JS は APK に同梱） |
+| **ホットリロード** | あり（1〜3 秒で反映） | なし（毎回ビルドが必要） |
+| **expo-dev-client** | あり（Dev Menu 使用可） | なし |
+| **`__DEV__`** | `true` | `false` |
+| **エラー画面** | あり（Red Box / Yellow Box） | なし（クラッシュ → 白画面） |
+| **ビルド時間** | 初回: 5〜10 分 / 以降: 不要 | 毎回: 10〜20 分 |
+| **1 サイクル** | コード保存 → 1〜3 秒 | コード変更 → ビルド → 転送 → 起動 |
+
+## いつどちらを使うか
+
+### Dev Build を使う場面
+- コードを頻繁に変更する日常の開発
+- UI の微調整（色・レイアウト・アニメーション）
+- バグの調査・デバッグ
+- 新機能のプロトタイピング
+
+### Preview Build を使う場面
+- PR マージ前の最終確認（本番に近い動作）
+- パフォーマンステスト（`__DEV__=false` の実行速度）
+- AdMob 広告の動作確認（dev では表示されない場合がある）
+- Maestro E2E テスト
+
+## Dev Build の準備
+
+### 1. APK をビルド
+
+```bash
+# EAS Cloud でビルド（推奨）
+npx eas-cli@latest build -p android --profile development
+
+# またはローカルビルド
+npx eas-cli@latest build -p android --profile development --local --output dist/repolog-dev.apk
+```
+
+### 2. APK をインストール
+
+```bash
+# ローカルビルドの場合
+env -u ADB_SERVER_SOCKET adb install -r dist/repolog-dev.apk
+
+# EAS Cloud ビルドの場合
+# → ビルド完了後に表示される URL からダウンロードしてインストール
+# → または EAS CLI でインストール
+npx eas-cli@latest build:run -p android --profile development
+```
+
+### 3. 開発セッションを開始
+
+```bash
+# ワンコマンドで ADB 確認 + ポートフォワーディング + Metro 起動
+bash scripts/dev-start.sh
+
+# キャッシュクリアして起動（キャッシュ不整合時）
+bash scripts/dev-start.sh --clean
+
+# カスタムポート
+bash scripts/dev-start.sh --port 8082
+```
+
+### 4. デバイスでアプリを起動
+
+1. デバイスで Repolog アプリを開く
+2. Dev Menu が表示される → 自動で Metro に接続
+3. 接続されない場合: Dev Menu > "Enter URL manually" > `localhost:8081`
+
+## Preview Build の準備
+
+```bash
+# ローカルビルド（推奨: CI 不要で高速）
+pnpm build:android:apk:local
+
+# デバイスにインストール
+pnpm install:device
+```
+
+## トラブルシューティング
+
+| 症状 | 原因 | 対処法 |
+|------|------|--------|
+| アプリに "No development server" と表示 | Metro が動いていない | `bash scripts/dev-start.sh` |
+| アプリが Metro に接続できない | ポートフォワーディングが切れた | `env -u ADB_SERVER_SOCKET adb reverse tcp:8081 tcp:8081` |
+| 古いバンドルが表示される | Metro キャッシュ | `bash scripts/dev-start.sh --clean` |
+| Dev Build APK がインストールできない | Preview Build と競合 | 先に Preview Build をアンインストール |
+| "Invariant Violation" エラー | ネイティブモジュール不一致 | Dev Build APK を再ビルド |
+
+## 参考
+
+- `eas.json`: ビルドプロファイル定義
+- `scripts/dev-start.sh`: 開発セッション起動スクリプト
+- `docs/how-to/development/android_debug.md`: ADB セットアップ・デバッグ全般

--- a/scripts/dev-start.sh
+++ b/scripts/dev-start.sh
@@ -1,0 +1,98 @@
+#!/usr/bin/env bash
+# dev-start.sh — One-command development session startup for Repolog
+# Usage: bash scripts/dev-start.sh [--clean] [--port PORT]
+#
+# This script:
+#   1. Verifies ADB connection to a physical device
+#   2. Sets up port forwarding (adb reverse) for Metro bundler
+#   3. Starts Metro bundler with expo-dev-client support
+#
+# Prerequisites:
+#   - Dev build APK installed on device (see docs/how-to/development/android_debug.md)
+#   - USB debugging enabled on device
+#   - Device connected via USB
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PROJECT_ROOT="$(cd "$SCRIPT_DIR/.." && pwd)"
+
+# --- Default values ---
+CLEAN=false
+PORT=8081
+
+# --- Parse arguments ---
+usage() {
+  cat <<USAGE
+Usage: $0 [OPTIONS]
+
+Options:
+  --clean       Clear Metro cache before starting
+  --port PORT   Metro bundler port (default: 8081)
+  -h, --help    Show this help
+
+Examples:
+  bash scripts/dev-start.sh              # Normal start
+  bash scripts/dev-start.sh --clean      # Start with cache clear
+  bash scripts/dev-start.sh --port 8082  # Custom port
+USAGE
+  exit 0
+}
+
+while [[ $# -gt 0 ]]; do
+  case "$1" in
+    --clean) CLEAN=true; shift ;;
+    --port)
+      if [[ -z "${2:-}" ]]; then
+        echo "ERROR: --port requires a value" >&2
+        exit 1
+      fi
+      PORT="$2"; shift 2
+      ;;
+    -h|--help) usage ;;
+    *)
+      echo "ERROR: Unknown option: $1" >&2
+      usage
+      ;;
+  esac
+done
+
+cd "$PROJECT_ROOT"
+
+# --- Step 1: Verify ADB connection ---
+echo "=== Step 1: Checking ADB connection ==="
+# WSL2 workaround: unset ADB_SERVER_SOCKET to avoid router-IP socket issue
+ADB_CMD="env -u ADB_SERVER_SOCKET adb"
+
+if ! $ADB_CMD devices 2>/dev/null | grep -q 'device$'; then
+  echo "ERROR: No Android device found."
+  echo ""
+  echo "Troubleshooting:"
+  echo "  1. Is the device connected via USB?"
+  echo "  2. Is USB debugging enabled? (Settings > Developer options > USB debugging)"
+  echo "  3. Did you authorize the PC on the device? (check for USB debugging dialog)"
+  echo "  4. Try: env -u ADB_SERVER_SOCKET adb devices"
+  exit 1
+fi
+
+DEVICE=$($ADB_CMD devices | grep 'device$' | head -1 | awk '{print $1}')
+echo "  Device found: $DEVICE"
+
+# --- Step 2: Set up port forwarding ---
+echo ""
+echo "=== Step 2: Setting up port forwarding (port $PORT) ==="
+$ADB_CMD reverse tcp:"$PORT" tcp:"$PORT"
+echo "  adb reverse tcp:$PORT tcp:$PORT — OK"
+
+# --- Step 3: Start Metro bundler ---
+echo ""
+echo "=== Step 3: Starting Metro bundler ==="
+if [ "$CLEAN" = true ]; then
+  echo "  Mode: --clean (clearing Metro cache)"
+  echo ""
+  npx expo start --dev-client --port "$PORT" --clear
+else
+  echo "  Mode: normal"
+  echo ""
+  npx expo start --dev-client --port "$PORT"
+fi


### PR DESCRIPTION
## Summary
- 開発ビルド（expo-dev-client）+ Metro 接続のワンコマンド起動スクリプトを追加
- Dev Build vs Preview Build の使い分けガイドを作成

## Type
docs / chore

## Related links
- Closes #106
- Depends on: #105 (adb install 手順)

## Purpose (Why)
Preview ビルドでの開発は 1 サイクル 10〜20 分かかる。Dev Build + Metro で 1〜3 秒のホットリロードを実現し、開発効率を大幅に向上させる。

## Changes (What)
1. `scripts/dev-start.sh` — ADB 確認 → ポートフォワーディング → Metro 起動
   - `--clean`: キャッシュクリアオプション
   - `--port PORT`: カスタムポート
   - WSL2 の `ADB_SERVER_SOCKET` ワークアラウンド内蔵
2. `docs/how-to/development/dev_vs_preview_builds.md` — 比較表・使い分け・トラブルシューティング
3. `docs/how-to/development/android_debug.md` — Section 9 追加

## Acceptance Criteria
- [x] `scripts/dev-start.sh` が構文エラーなし（`bash -n` pass）
- [x] `android_debug.md` に Dev Build セクション追加済み
- [x] `dev_vs_preview_builds.md` 作成済み
- [x] `pnpm verify` 全ゲートパス
- [ ] 手動: `dev-start.sh` がデバイスで動作すること

## Testing
- [x] `bash -n scripts/dev-start.sh` — syntax OK
- [x] `pnpm verify` — all 4 gates pass

## Risk and rollback
- Risk: Low — スクリプトと docs のみ
- Rollback: revert commit

🤖 Generated with [Claude Code](https://claude.com/claude-code)