### PR TITLE
fix: レポート作成日時の9時間ずれを修正（Hermesタイムゾーン対応）

### DIFF
--- a/__tests__/pdfUtils.test.ts
+++ b/__tests__/pdfUtils.test.ts
@@ -1,3 +1,8 @@
+jest.mock('expo-localization', () => ({
+  getCalendars: () => [{}],
+  getLocales: () => [{ languageCode: 'en' }],
+}));
+
 import {
   buildPdfExportFileName,
   chunkPhotos,

--- a/src/features/pdf/pdfUtils.ts
+++ b/src/features/pdf/pdfUtils.ts
@@ -1,3 +1,5 @@
+import * as Localization from 'expo-localization';
+
 import type { Photo, Report } from '@/src/types/models';
 
 export type PaperSize = 'A4' | 'Letter';
@@ -15,16 +17,47 @@ const FILE_NAME_DUPLICATED_UNDERSCORES = /_+/g;
 const FILE_NAME_EDGE_UNDERSCORES = /^_+|_+$/g;
 const MAX_FILE_NAME_REPORT_PART_LENGTH = 30;
 
+const getDeviceTimeZone = (): string | undefined => {
+  try {
+    return Localization.getCalendars()[0]?.timeZone ?? undefined;
+  } catch {
+    return undefined;
+  }
+};
+
+const getLocalParts = (date: Date) => {
+  try {
+    const tz = getDeviceTimeZone();
+    const opts: Intl.DateTimeFormatOptions = {
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    };
+    if (tz) opts.timeZone = tz;
+    const parts = new Intl.DateTimeFormat('en-CA', opts).formatToParts(date);
+    const get = (type: Intl.DateTimeFormatPartTypes) =>
+      parts.find((p) => p.type === type)?.value ?? '';
+    return { year: get('year'), month: get('month'), day: get('day'), hour: get('hour'), minute: get('minute') };
+  } catch {
+    const pad = (v: number) => String(v).padStart(2, '0');
+    return {
+      year: String(date.getFullYear()),
+      month: pad(date.getMonth() + 1),
+      day: pad(date.getDate()),
+      hour: pad(date.getHours()),
+      minute: pad(date.getMinutes()),
+    };
+  }
+};
+
 export const formatDateTime = (iso: string) => {
   const date = new Date(iso);
   if (Number.isNaN(date.getTime())) return iso;
-  const pad = (value: number) => String(value).padStart(2, '0');
-  const year = date.getFullYear();
-  const month = pad(date.getMonth() + 1);
-  const day = pad(date.getDate());
-  const hours = pad(date.getHours());
-  const minutes = pad(date.getMinutes());
-  return `${year}-${month}-${day} ${hours}:${minutes}`;
+  const { year, month, day, hour, minute } = getLocalParts(date);
+  return `${year}-${month}-${day} ${hour}:${minute}`;
 };
 
 export const splitCommentIntoPages = (comment: string, charsPerPage = 1200) => {
@@ -72,13 +105,8 @@ const normalizeFileNamePart = (value: string, maxLength?: number) => {
 const formatFileNameTimestamp = (iso: string) => {
   const date = new Date(iso);
   const safeDate = Number.isNaN(date.getTime()) ? new Date() : date;
-  const pad = (value: number) => String(value).padStart(2, '0');
-  const year = safeDate.getFullYear();
-  const month = pad(safeDate.getMonth() + 1);
-  const day = pad(safeDate.getDate());
-  const hours = pad(safeDate.getHours());
-  const minutes = pad(safeDate.getMinutes());
-  return `${year}${month}${day}_${hours}${minutes}`;
+  const { year, month, day, hour, minute } = getLocalParts(safeDate);
+  return `${year}${month}${day}_${hour}${minute}`;
 };
 
 export const buildPdfExportFileName = (params: {


### PR DESCRIPTION
# 概要
レポート作成日時がUTCで表示され、JSTとの差分で9時間ずれて見える問題を修正。`Intl.DateTimeFormat` + `expo-localization` のデバイスタイムゾーンを使用して確実にローカル時刻を表示する。

---

## 0. 種別
- [x] fix（バグ修正）

---

## 1. 関連リンク
- Issue: #153

---

## 2. 目的（Why）
- ユーザー価値: レポートの作成日時が正しいローカル時刻で表示される
- バグの再現条件: Preview Build（Hermesエンジン）で、UTC+9環境のデバイスでレポートを作成すると、作成日時が9時間ずれて表示される

---

## 3. 変更点（What）
- `formatDateTime()` と `formatFileNameTimestamp()` を `Intl.DateTimeFormat` ベースの実装に変更
- `expo-localization.getCalendars()` からデバイスのタイムゾーンを取得し、`Intl.DateTimeFormat` に明示的に渡す
- `getLocalParts()` ヘルパー関数を追加（共通の日時パーツ取得ロジック）
- `Intl` が利用できない場合は旧来の `getHours()` 等へフォールバック
- テストで `expo-localization` モックをオーバーライド（デフォルトモックの 'America/New_York' によるTZずれを回避）

---

## 4. 受け入れ条件（Acceptance Criteria）
- [x] 条件1: Preview Buildでレポート作成日時がデバイスのローカル時刻で表示される
- [x] 条件2: ホーム画面、レポート編集画面、PDF表紙の3箇所で同一の正しい時刻
- [x] 条件3: DBに保存されるISO文字列（UTC）は変更なし
- [x] 条件4: 全Jestテスト通過（51/51）

---

## 5. 影響範囲（Impact）
### 5-1. 影響する箇所
- 画面（UI）: ホーム画面、レポート編集画面、PDFプレビュー/表紙
- 機能: `formatDateTime()`, `formatFileNameTimestamp()`, `buildPdfExportFileName()`
- 影響する層:
  - [x] 両方

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし（DBの保存形式は変更なし、表示ロジックのみ変更）

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [x] あり（全言語で日時表示に影響）
- 端末/OS差分の懸念:
  - [x] なし（expo-localizationがOS依存部を吸収）

---

## 6. 動作確認（How to test）
### 6-1. 自動テスト
- [x] pnpm test（結果：✅ 51/51 passed）

### 6-2. 手動確認
1. Preview Buildをデバイスにインストール
2. レポートを新規作成（現在時刻を記録）
3. ホーム画面のレポート一覧で作成日時を確認
4. PDFプレビューの表紙で作成日時を確認
- 期待結果: デバイスのローカル時刻が表示される
- 実際結果: 期待通り

### 6-3. 再現手順
- Before: 16:00 JST に作成 → 「07:00」と表示（UTC）
- After: 16:00 JST に作成 → 「16:00」と表示（JST）

---

## 8. Docs影響
- [x] どれも不要（理由：内部バグ修正、外部仕様に影響なし）

---

## 9. リスク評価 & ロールバック
### 9-1. リスク
- 想定リスク: `Intl.DateTimeFormat` が特定環境で異なるフォーマットを返す可能性
- 検知方法: Preview Buildでの手動確認 + Jestテスト
- 影響の大きさ:
  - [x] 低（困るが致命傷ではない）

### 9-2. ロールバック
- 戻し方: このPRをrevert

---

## 12. PRサイズ
- [x] 小（〜200行）

---

## 13. チェックリスト（DoD）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲を書いた
- [x] 動作確認を記載した（自動/手動）
- [x] CIが通った
- [x] docs影響を判定した
- [x] リスクとロールバックを書いた

🤖 Generated with [Claude Code](https://claude.com/claude-code)