### PR TITLE
fix: 写真の長押しドラッグ時のスクロール暴走を修正

### DIFF
--- a/src/features/reports/ReportEditorScreen.tsx
+++ b/src/features/reports/ReportEditorScreen.tsx
@@ -669,7 +669,7 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
           testID={`e2e_photo_slot_${index}_${marker}`}
           style={[styles.photoCard, { backgroundColor: colors.photoCardBg }, isActive && styles.photoCardActive]}>
           <View style={styles.photoToolbar}>
-            <Pressable onLongPress={drag} delayLongPress={160} style={styles.photoDragHandle} accessibilityLabel={t.a11yReorderPhoto} accessibilityRole="button">
+            <Pressable onLongPress={drag} delayLongPress={200} style={styles.photoDragHandle} accessibilityLabel={t.a11yReorderPhoto} accessibilityRole="button">
               <GripVertical size={16} color={colors.textMuted} strokeWidth={ICON_STROKE_WIDTH} />
             </Pressable>
             <Text style={[styles.photoIndexLabel, { color: colors.textSecondary }]}>{index + 1}</Text>
@@ -884,7 +884,9 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
                 data={photos}
                 keyExtractor={(item) => item.id}
                 renderItem={renderPhotoItem}
-                activationDistance={12}
+                activationDistance={20}
+                autoscrollThreshold={80}
+                autoscrollSpeed={150}
                 onDragEnd={({ data }) => {
                   void handlePhotoReorder(data);
                 }}


### PR DESCRIPTION
## Summary
- `activationDistance` を 12→20pt に増加（意図しないドラッグ発動を抑制）
- `autoscrollThreshold` (80pt) と `autoscrollSpeed` (150) を明示設定
- `delayLongPress` を 160→200ms に増加

Closes #166

## Test plan
- [ ] 写真を長押ししても勝手にスクロールされない
- [ ] ドラッグ解除後に正常にスクロール可能
- [ ] ドラッグで並べ替えが正常に機能する
- [ ] lint / type-check / test 全通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)