### PR TITLE
feat: 写真ドラッグUX改善 + PDFテンプレート仕様準拠 + コメント表紙統合 (#173)

### DIFF
--- a/__tests__/pdfUtils.test.ts
+++ b/__tests__/pdfUtils.test.ts
@@ -6,7 +6,9 @@ jest.mock('expo-localization', () => ({
 import * as Localization from 'expo-localization';
 
 import {
+  COVER_COMMENT_CHAR_LIMIT,
   buildPdfExportFileName,
+  calculatePageCount,
   chunkPhotos,
   formatDateTime,
   photoLabel,
@@ -92,6 +94,35 @@ describe('pdfUtils', () => {
       reportName: '12345678901234567890123456789012345',
     });
     expect(fileName).toBe('20260209_0718_123456789012345678901234567890_Repolog.pdf');
+  });
+});
+
+describe('calculatePageCount', () => {
+  test('short comment fits on cover — no separate comment pages', () => {
+    // 10 chars is well under 800
+    expect(calculatePageCount('short', 4, 'standard')).toBe(1 + 0 + 2); // cover + 0 comment + 2 photo
+    expect(calculatePageCount('short', 4, 'large')).toBe(1 + 0 + 4);
+  });
+
+  test('empty comment fits on cover — no separate comment pages', () => {
+    expect(calculatePageCount('', 2, 'standard')).toBe(1 + 0 + 1);
+  });
+
+  test('comment at exactly the limit fits on cover', () => {
+    const exactLimit = 'a'.repeat(COVER_COMMENT_CHAR_LIMIT);
+    expect(calculatePageCount(exactLimit, 2, 'standard')).toBe(1 + 0 + 1);
+  });
+
+  test('long comment exceeding limit gets separate pages', () => {
+    const longComment = 'a'.repeat(COVER_COMMENT_CHAR_LIMIT + 1);
+    // 801 chars -> 1 page (splitCommentIntoPages with 1200 chars/page)
+    expect(calculatePageCount(longComment, 2, 'standard')).toBe(1 + 1 + 1);
+  });
+
+  test('very long comment splits into multiple pages', () => {
+    const veryLong = 'a'.repeat(2500);
+    // 2500 chars -> ceil(2500/1200) = 3 comment pages
+    expect(calculatePageCount(veryLong, 2, 'standard')).toBe(1 + 3 + 1);
   });
 });
 

--- a/src/features/pdf/pdfTemplate.ts
+++ b/src/features/pdf/pdfTemplate.ts
@@ -4,6 +4,7 @@ import * as ImageManipulator from 'expo-image-manipulator';
 import type { Photo, Report } from '@/src/types/models';
 import { buildPdfFontCss, pdfFontStack } from './pdfFonts';
 import {
+  COVER_COMMENT_CHAR_LIMIT,
   PAPER_SIZES,
   type PaperSize,
   type PdfLayout,
@@ -117,7 +118,7 @@ const buildFontSelectionText = (input: PdfTemplateInput) => {
   return chunks.join('\n');
 };
 
-const buildCover = (input: PdfTemplateInput, pageCount: number) => {
+const buildCover = (input: PdfTemplateInput, pageCount: number, commentText?: string) => {
   const title = escapeHtml(reportTitle(input.report));
   const createdAt = escapeHtml(formatDateTime(input.report.createdAt));
   const weather = escapeHtml(input.weatherLabel ?? input.report.weather ?? '');
@@ -128,25 +129,34 @@ const buildCover = (input: PdfTemplateInput, pageCount: number) => {
       : '-';
   const address = input.report.address ?? '-';
 
+  const commentBlock = commentText != null
+    ? `
+          <div class="comment-block no-break">
+            <h2 class="section-title">${escapeHtml(getLabel(input, 'comment'))}</h2>
+            <div class="comment-text">${escapeHtml(commentText || '-')}</div>
+          </div>`
+    : '';
+
   return `
-    <section class="page">
+    <section class="page cover">
       <div class="page-inner">
         <div class="page-main">
-          <h1 class="title">${title}</h1>
-          <div class="meta">
-            <div><span class="label">${escapeHtml(getLabel(input, 'createdAt'))}</span><span>${createdAt}</span></div>
-            <div><span class="label">${escapeHtml(getLabel(input, 'reportName'))}</span><span>${reportName}</span></div>
-            <div><span class="label">${escapeHtml(getLabel(input, 'address'))}</span><span>${escapeHtml(address)}</span></div>
-            <div><span class="label">${escapeHtml(getLabel(input, 'location'))}</span><span>${escapeHtml(location)}</span></div>
-            <div><span class="label">${escapeHtml(getLabel(input, 'weather'))}</span><span>${weather || '-'}</span></div>
-            <div><span class="label">${escapeHtml(getLabel(input, 'photoCount'))}</span><span>${input.photos.length} ${escapeHtml(getLabel(input, 'photos'))}</span></div>
-            <div><span class="label">${escapeHtml(getLabel(input, 'pageCount'))}</span><span>${pageCount} ${escapeHtml(getLabel(input, 'pages'))}</span></div>
+          <h1 class="report-title">${title}</h1>
+          <div class="meta-grid">
+            <div class="meta-k">${escapeHtml(getLabel(input, 'createdAt'))}</div><div class="meta-v">${createdAt}</div>
+            <div class="meta-k">${escapeHtml(getLabel(input, 'reportName'))}</div><div class="meta-v">${reportName}</div>
+            <div class="meta-k">${escapeHtml(getLabel(input, 'address'))}</div><div class="meta-v">${escapeHtml(address)}</div>
+            <div class="meta-k">${escapeHtml(getLabel(input, 'location'))}</div><div class="meta-v">${escapeHtml(location)}</div>
+            <div class="meta-k">${escapeHtml(getLabel(input, 'weather'))}</div><div class="meta-v">${weather || '-'}</div>
+            <div class="meta-k">${escapeHtml(getLabel(input, 'photoCount'))}</div><div class="meta-v">${input.photos.length} ${escapeHtml(getLabel(input, 'photos'))}</div>
+            <div class="meta-k">${escapeHtml(getLabel(input, 'pageCount'))}</div><div class="meta-v">${pageCount} ${escapeHtml(getLabel(input, 'pages'))}</div>
           </div>
+          ${commentBlock}
         </div>
-        <div class="page-footer">
+        <footer class="page-footer">
           <span>${escapeHtml(input.appName ?? 'Repolog')}</span>
           <span>1/${pageCount}</span>
-        </div>
+        </footer>
         ${input.isPro ? '' : '<div class="watermark">Created by Repolog</div>'}
       </div>
     </section>
@@ -159,16 +169,16 @@ const buildCommentPages = (input: PdfTemplateInput, startIndex: number, pageCoun
   pages.forEach((text, index) => {
     const pageNumber = startIndex + index;
     out.push(`
-      <section class="page">
+      <section class="page comment-page">
         <div class="page-inner">
           <div class="page-main">
             <h2 class="section-title">${escapeHtml(getLabel(input, 'comment'))}</h2>
-            <div class="comment">${escapeHtml(text || '-')}</div>
+            <div class="comment-text">${escapeHtml(text || '-')}</div>
           </div>
-          <div class="page-footer">
+          <footer class="page-footer">
             <span></span>
             <span>${pageNumber}/${pageCount}</span>
-          </div>
+          </footer>
         </div>
       </section>
     `);
@@ -182,6 +192,8 @@ const buildPhotoPages = async (
   perPage: number,
   pageCount: number,
 ) => {
+  const layout = input.layout === 'large' ? 'large' : 'standard';
+  const gridClass = layout === 'large' ? 'one' : 'two';
   const chunks = chunkPhotos(input.photos, perPage);
   const out: string[] = [];
   let photoCounter = 0;
@@ -198,31 +210,40 @@ const buildPhotoPages = async (
           const src = await fileToDataUri(photo.localUri, config);
           return `
             <div class="photo-slot">
-              <div class="photo-label">${escapeHtml(label)}</div>
-              <img class="photo" src="${src}" alt="${escapeHtml(label)}" />
+              <div class="photo-frame">
+                <img class="photo" src="${src}" alt="${escapeHtml(label)}" />
+                <div class="photo-no">${escapeHtml(label)}</div>
+              </div>
             </div>
           `;
         } catch {
           console.warn(`[PDF] Failed to load photo: ${photo.localUri}`);
           return `
             <div class="photo-slot">
-              <div class="photo-label">${escapeHtml(label)}</div>
+              <div class="photo-frame">
+                <div class="photo-no">${escapeHtml(label)}</div>
+              </div>
             </div>
           `;
         }
       }),
     );
 
+    // Add empty slot for odd photo count in standard layout
+    if (perPage === 2 && chunk.length < perPage) {
+      slots.push('<div class="photo-slot empty"></div>');
+    }
+
     out.push(`
-      <section class="page">
+      <section class="page photo-page ${layout}">
         <div class="page-inner">
-          <div class="page-main photo-grid layout-${input.layout}">
+          <div class="page-main photo-grid ${gridClass}">
             ${slots.join('')}
           </div>
-          <div class="page-footer">
+          <footer class="page-footer">
             <span></span>
             <span>${pageNumber}/${pageCount}</span>
-          </div>
+          </footer>
         </div>
       </section>
     `);
@@ -293,64 +314,105 @@ const buildCss = async (input: PdfTemplateInput) => {
     border-top: 1px solid rgba(0,0,0,0.08);
     padding-top: 2mm;
   }
-  .title {
-    margin: 0 0 8mm 0;
-    font-size: 20pt;
+  .report-title {
+    text-align: center;
+    font-size: 24pt;
+    font-weight: 800;
+    margin: 0 0 6mm 0;
+    padding-bottom: 4mm;
+    border-bottom: 2px solid rgba(0,0,0,0.75);
   }
-  .meta {
+  .meta-grid {
     display: grid;
-    gap: 4mm;
-    font-size: 11pt;
+    grid-template-columns: 32mm 1fr;
+    column-gap: 6mm;
+    row-gap: 3mm;
+    text-align: start;
+    margin-bottom: 6mm;
   }
-  .label {
-    display: inline-block;
-    width: 24mm;
-    color: var(--muted);
+  .meta-k {
+    font-weight: 700;
+    color: #444;
   }
-  .section-title {
-    margin: 0 0 4mm 0;
-    font-size: 14pt;
-  }
-  .comment {
-    white-space: pre-wrap;
+  .meta-v {
+    font-weight: 600;
+    overflow-wrap: anywhere;
     word-break: break-word;
   }
-  .photo-grid {
-    display: grid;
-    gap: 6mm;
+  .section-title {
+    margin: 0 0 3mm 0;
+    font-size: 13pt;
+    font-weight: 800;
+    color: #333;
+    border-left: 5px solid rgba(0,0,0,0.65);
+    padding-left: 3mm;
   }
-  .photo-grid.layout-standard {
+  .comment-text {
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+    word-break: break-word;
+    font-size: 11pt;
+    line-height: 1.45;
+  }
+  .comment-block {
+    margin-top: 6mm;
+    padding: 5mm;
+    border: 1px solid rgba(0,0,0,0.10);
+    border-radius: 3mm;
+    background: #fafafa;
+  }
+  .no-break {
+    break-inside: avoid;
+    page-break-inside: avoid;
+  }
+  .photo-grid {
+    height: 100%;
+    display: grid;
+    gap: var(--gap);
+  }
+  .photo-grid.two {
     grid-template-rows: 1fr 1fr;
   }
-  .photo-grid.layout-large {
+  .photo-grid.one {
     grid-template-rows: 1fr;
   }
   .photo-slot {
-    position: relative;
+    min-height: 0;
+  }
+  .photo-slot.empty {
+    border: 1px dashed rgba(0,0,0,0.10);
+    border-radius: 3mm;
+  }
+  .photo-frame {
+    height: 100%;
     border: 1px solid var(--border);
+    border-radius: 3mm;
+    background: #fff;
+    overflow: hidden;
     display: flex;
     align-items: center;
     justify-content: center;
-    overflow: hidden;
+    position: relative;
   }
   .photo {
-    max-width: 100%;
-    max-height: 100%;
+    width: 100%;
+    height: 100%;
     object-fit: contain;
+    display: block;
   }
-  .photo-label {
+  .photo-no {
     position: absolute;
-    top: 3mm;
-    right: 3mm;
-    font-size: 9pt;
-    color: var(--muted);
+    right: 2mm;
+    bottom: 2mm;
+    font-size: 8pt;
+    color: rgba(0,0,0,0.70);
   }
   .watermark {
     position: absolute;
     right: var(--page-pad);
     bottom: calc(var(--page-pad) + var(--footer-h));
     font-size: 9pt;
-    color: rgba(0,0,0,0.3);
+    color: rgba(0,0,0,0.25);
   }
   `;
 };
@@ -359,17 +421,20 @@ export async function buildPdfHtml(input: PdfTemplateInput) {
   const layout = input.layout === 'large' ? 'large' : 'standard';
   const perPage = layout === 'large' ? 1 : 2;
   const css = await buildCss(input);
-  const commentPages = splitCommentIntoPages(input.report.comment ?? '');
+  const comment = input.report.comment ?? '';
+  const isCommentOnCover = comment.length <= COVER_COMMENT_CHAR_LIMIT;
+  const commentPageCount = isCommentOnCover ? 0 : splitCommentIntoPages(comment).length;
   const photoPageCount = Math.ceil(input.photos.length / perPage);
-  const pageCount = 1 + commentPages.length + photoPageCount;
-  const cover = buildCover(input, pageCount);
-  const commentPageHtml = buildCommentPages(input, 2, pageCount);
+  const pageCount = 1 + commentPageCount + photoPageCount;
+  const cover = buildCover(input, pageCount, isCommentOnCover ? comment : undefined);
+  const commentPageHtml = isCommentOnCover ? [] : buildCommentPages(input, 2, pageCount);
   const photoStartIndex = 2 + commentPageHtml.length;
   const photoPages = await buildPhotoPages(input, photoStartIndex, perPage, pageCount);
+  const lang = escapeHtml(input.localeHint ?? 'en');
 
   return `
   <!DOCTYPE html>
-  <html lang="en">
+  <html lang="${lang}">
     <head>
       <meta charset="utf-8" />
       <meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/src/features/pdf/pdfUtils.ts
+++ b/src/features/pdf/pdfUtils.ts
@@ -11,6 +11,7 @@ export const PAPER_SIZES = {
 } as const;
 
 export const DEFAULT_TIME_FORMAT = 'YYYY-MM-DD HH:mm';
+export const COVER_COMMENT_CHAR_LIMIT = 800;
 const FILE_NAME_FORBIDDEN_CHARS = /[\/\\:*?"<>|]/g;
 const FILE_NAME_SPACES = /\s+/g;
 const FILE_NAME_DUPLICATED_UNDERSCORES = /_+/g;
@@ -85,10 +86,11 @@ export const photoLabel = (index: number) => `Photo ${index + 1}`;
 export const reportTitle = (report: Report) => report.reportName ?? 'Untitled Report';
 
 export const calculatePageCount = (comment: string, photoCount: number, layout: PdfLayout) => {
-  const commentPages = splitCommentIntoPages(comment);
+  const isCommentOnCover = comment.length <= COVER_COMMENT_CHAR_LIMIT;
+  const commentPages = isCommentOnCover ? 0 : splitCommentIntoPages(comment).length;
   const perPage = layout === 'large' ? 1 : 2;
   const photoPages = Math.ceil(photoCount / perPage);
-  return 1 + commentPages.length + photoPages;
+  return 1 + commentPages + photoPages;
 };
 
 const normalizeFileNamePart = (value: string, maxLength?: number) => {

--- a/src/features/reports/ReportEditorScreen.tsx
+++ b/src/features/reports/ReportEditorScreen.tsx
@@ -14,6 +14,7 @@ import * as FileSystem from 'expo-file-system/legacy';
 import {
   NestableDraggableFlatList,
   NestableScrollContainer,
+  ScaleDecorator,
   type RenderItemParams,
 } from 'react-native-draggable-flatlist';
 import { SafeAreaView } from 'react-native-safe-area-context';
@@ -665,35 +666,39 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
       const index = getIndex() ?? item.orderIndex;
       const marker = extractPhotoMarker(item.localUri);
       return (
-        <View
-          testID={`e2e_photo_slot_${index}_${marker}`}
-          style={[styles.photoCard, { backgroundColor: colors.photoCardBg }, isActive && styles.photoCardActive]}>
-          <View style={styles.photoToolbar}>
-            <Pressable onLongPress={drag} delayLongPress={200} style={styles.photoDragHandle} accessibilityLabel={t.a11yReorderPhoto} accessibilityRole="button">
-              <GripVertical size={16} color={colors.textMuted} strokeWidth={ICON_STROKE_WIDTH} />
-            </Pressable>
-            <Text style={[styles.photoIndexLabel, { color: colors.textSecondary }]}>{index + 1}</Text>
-            <View style={styles.photoToolbarSpacer} />
-            {__DEV__ && (
-              <Pressable
-                testID={`e2e_photo_delete_now_${index}`}
-                onPress={() => {
-                  void handleDeletePhoto(item);
-                }}
-                style={styles.photoDeleteNowButton}>
-                <Text style={styles.photoDeleteNowText}>-</Text>
+        <ScaleDecorator activeScale={1.03}>
+          <View
+            testID={`e2e_photo_slot_${index}_${marker}`}
+            style={[styles.photoCard, { backgroundColor: colors.photoCardBg }, isActive && styles.photoCardActive]}>
+            <View style={styles.photoToolbar}>
+              <Pressable onLongPress={drag} delayLongPress={200} style={styles.photoDragHandle} accessibilityLabel={t.a11yReorderPhoto} accessibilityRole="button">
+                <GripVertical size={16} color={colors.textMuted} strokeWidth={ICON_STROKE_WIDTH} />
               </Pressable>
-            )}
-            <Pressable
-              testID={`e2e_photo_delete_${index}`}
-              onPress={() => confirmDeletePhoto(item)}
-              hitSlop={8}
-              style={styles.photoDeleteButton}>
-              <Text style={styles.photoDeleteButtonText}>×</Text>
+              <Text style={[styles.photoIndexLabel, { color: colors.textSecondary }]}>{index + 1}</Text>
+              <View style={styles.photoToolbarSpacer} />
+              {__DEV__ && (
+                <Pressable
+                  testID={`e2e_photo_delete_now_${index}`}
+                  onPress={() => {
+                    void handleDeletePhoto(item);
+                  }}
+                  style={styles.photoDeleteNowButton}>
+                  <Text style={styles.photoDeleteNowText}>-</Text>
+                </Pressable>
+              )}
+              <Pressable
+                testID={`e2e_photo_delete_${index}`}
+                onPress={() => confirmDeletePhoto(item)}
+                hitSlop={8}
+                style={styles.photoDeleteButton}>
+                <Text style={styles.photoDeleteButtonText}>×</Text>
+              </Pressable>
+            </View>
+            <Pressable onLongPress={drag} delayLongPress={200}>
+              <Image source={{ uri: item.localUri }} style={[styles.photoThumb, { backgroundColor: colors.photoCardBg }]} contentFit="cover" />
             </Pressable>
           </View>
-          <Image source={{ uri: item.localUri }} style={[styles.photoThumb, { backgroundColor: colors.photoCardBg }]} contentFit="cover" />
-        </View>
+        </ScaleDecorator>
       );
     },
     [colors.photoCardBg, colors.textMuted, colors.textSecondary, confirmDeletePhoto, handleDeletePhoto, t.a11yReorderPhoto],
@@ -1197,7 +1202,6 @@ const styles = StyleSheet.create({
     overflow: 'hidden',
   },
   photoCardActive: {
-    opacity: 0.85,
     elevation: 4,
     shadowColor: '#000',
     shadowOpacity: 0.15,


### PR DESCRIPTION
## Summary
- 写真画像の長押しでドラッグ並べ替え可能に（ScaleDecoratorアニメーション付き）
- PDF HTML/CSSを`docs/reference/pdf_template.md`仕様に全面準拠（12項目修正）
- 短コメント(<=800字)を表紙に統合し余白を解消

## Changes
| ファイル | 変更 |
|---------|------|
| `ReportEditorScreen.tsx` | ScaleDecorator + 写真Pressable wrap |
| `pdfTemplate.ts` | CSS全面改修 + HTML仕様準拠 + コメント表紙統合 |
| `pdfUtils.ts` | `COVER_COMMENT_CHAR_LIMIT` + `calculatePageCount`更新 |
| `pdfUtils.test.ts` | calculatePageCountテスト5件追加 |

## Test plan
- [x] `npx jest __tests__/pdfUtils.test.ts __tests__/pdfImageConfig.test.ts` — 25 tests pass
- [x] TypeScript `tsc --noEmit` — no errors
- [ ] 実機: 写真長押しドラッグで並べ替え確認
- [ ] 実機: PDFプレビューでタイトル中央・メタグリッド・写真ラベル右下を確認
- [ ] 実機: 短コメントが表紙に表示されることを確認

Closes #173

🤖 Generated with [Claude Code](https://claude.com/claude-code)