### PR TITLE
feat: 住所フォーマットのロケール対応 + 作成日時の編集機能

### DIFF
--- a/src/features/pdf/pdfUtils.ts
+++ b/src/features/pdf/pdfUtils.ts
@@ -61,6 +61,16 @@ export const formatDateTime = (iso: string) => {
   return `${year}-${month}-${day} ${hour}:${minute}`;
 };
 
+export const parseDateTimeInput = (text: string): string | null => {
+  const match = text.trim().match(/^(\d{4})-(\d{1,2})-(\d{1,2})\s+(\d{1,2}):(\d{1,2})$/);
+  if (!match) return null;
+  const [, y, m, d, h, min] = match;
+  const date = new Date(Number(y), Number(m) - 1, Number(d), Number(h), Number(min));
+  if (Number.isNaN(date.getTime())) return null;
+  if (date.getFullYear() !== Number(y) || date.getMonth() !== Number(m) - 1 || date.getDate() !== Number(d)) return null;
+  return date.toISOString();
+};
+
 export const splitCommentIntoPages = (comment: string, charsPerPage = 1200) => {
   if (!comment) return [''];
   const chars = Array.from(comment);

--- a/src/features/reports/ReportEditorScreen.tsx
+++ b/src/features/reports/ReportEditorScreen.tsx
@@ -46,7 +46,7 @@ import {
   remainingCommentChars,
   splitTagInput,
 } from '@/src/features/reports/reportUtils';
-import { formatDateTime } from '@/src/features/pdf/pdfUtils';
+import { formatDateTime, parseDateTimeInput } from '@/src/features/pdf/pdfUtils';
 import { useSettingsStore } from '@/src/stores/settingsStore';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import { getCurrentLocationWithAddress } from '@/src/services/locationService';
@@ -142,6 +142,7 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
   const [tagInput, setTagInput] = useState('');
   const [weather, setWeather] = useState<WeatherType>('none');
   const [createdAt, setCreatedAt] = useState<string>(new Date().toISOString());
+  const [dateText, setDateText] = useState(() => formatDateTime(new Date().toISOString()));
   const [locationState, setLocationState] = useState<LocationState>(emptyLocation);
   const [locationLoading, setLocationLoading] = useState(false);
   const [undoVisible, setUndoVisible] = useState(false);
@@ -211,6 +212,20 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
       mounted = false;
     };
   }, [loading, report, reportId]);
+
+  useEffect(() => {
+    setDateText(formatDateTime(createdAt));
+  }, [createdAt]);
+
+  const handleDateBlur = useCallback(() => {
+    const parsed = parseDateTimeInput(dateText);
+    if (parsed) {
+      setCreatedAt(parsed);
+      setDateText(formatDateTime(parsed));
+    } else {
+      setDateText(formatDateTime(createdAt));
+    }
+  }, [dateText, createdAt]);
 
   const handleFetchLocation = useCallback(async () => {
     if (!includeLocation || locationLoading) return;
@@ -763,7 +778,15 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
             />
 
             <Text style={[styles.fieldLabel, styles.fieldSpacing, { color: colors.textPrimary }]}>{t.createdAtLabel}</Text>
-            <Text style={[styles.value, { color: colors.textSecondary }]}>{formatDateTime(createdAt)}</Text>
+            <TextInput
+              style={[styles.input, { color: colors.textPrimary, backgroundColor: colors.surfaceHighlight, borderColor: 'rgba(0, 0, 0, 0)' }]}
+              value={dateText}
+              onChangeText={setDateText}
+              onBlur={handleDateBlur}
+              placeholder="YYYY-MM-DD HH:MM"
+              placeholderTextColor={colors.textPlaceholder}
+              keyboardType="numbers-and-punctuation"
+            />
 
             <Text style={[styles.fieldLabel, styles.fieldSpacing, { color: colors.textPrimary }]}>{t.weatherLabel}</Text>
             <View style={styles.weatherRow}>

--- a/src/services/locationService.ts
+++ b/src/services/locationService.ts
@@ -17,18 +17,18 @@ export type LocationResponse =
   | { ok: true; data: LocationResult }
   | { ok: false; reason: LocationFailureReason; error?: unknown };
 
+const CJK_LANGUAGES = new Set(['ja', 'ko', 'zh']);
+
 const formatAddress = (value?: Location.LocationGeocodedAddress | null) => {
   if (!value) return null;
-  const parts = [
-    value.street,
-    value.name,
-    value.city,
-    value.region,
-    value.postalCode,
-    value.country,
-  ].filter((part) => typeof part === 'string' && part.trim().length > 0);
-  if (parts.length === 0) return null;
-  return Array.from(new Set(parts)).join(', ');
+  const lang = Localization.getLocales()?.[0]?.languageCode;
+  const isCjk = lang != null && CJK_LANGUAGES.has(lang);
+  const parts = isCjk
+    ? [value.country, value.postalCode, value.region, value.city, value.name, value.street]
+    : [value.street, value.name, value.city, value.region, value.postalCode, value.country];
+  const filtered = parts.filter((part) => typeof part === 'string' && part.trim().length > 0);
+  if (filtered.length === 0) return null;
+  return Array.from(new Set(filtered)).join(', ');
 };
 
 export async function getCurrentLocationWithAddress(): Promise<LocationResponse> {


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）

レポートエディタ画面の UX 改善 2 件。住所表示をデバイスロケールに合わせた並び順に変更し、作成日時フィールドを手動編集可能にした。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [x] feat（機能追加）
- [ ] refactor（仕様非変更の整理）
- [ ] perf（性能改善）
- [ ] test（テスト追加/修正）
- [ ] docs（ドキュメント）
- [ ] chore（雑務：依存更新など）
- [ ] release（リリース準備）
- [ ] hotfix（緊急修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #186
- ADR: なし（小規模 UX 改善のため）
- 参照:
  - product_strategy: docs/explanation/product_strategy.md（P1: 現場で迷わせない、P6: 逆ジオコーディングはデバイス言語）
  - debug session: docs/reference/Debug/session_20260309_171236/summary.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値:
  - **住所**: CJK ユーザー（日本語/韓国語/中国語）にとって自然な大→小の表示順にする（例: `日本, 214-0013, 神奈川県, 川崎市, 82-4`）
  - **日時**: 過去の作業をまとめて報告書を作成するワークフローや、誤入力修正に対応
- バグの再現条件: N/A（機能追加）

---

## 3. 変更点（What / REQUIRED）
- `src/services/locationService.ts`: `formatAddress()` がデバイスロケール（`Localization.getLocales()[0].languageCode`）を検出し、CJK は大→小、Western は小→大で住所パーツを並べる
- `src/features/pdf/pdfUtils.ts`: `parseDateTimeInput()` を追加（`YYYY-MM-DD HH:MM` 形式の文字列を ISO 文字列に変換、バリデーション付き）
- `src/features/reports/ReportEditorScreen.tsx`:
  - 作成日時の表示を `Text`（読み取り専用）→ `TextInput`（編集可能）に変更
  - `dateText` state + `useEffect` 同期 + `handleDateBlur` バリデーション追加
  - 不正入力（例: 2月30日）は blur 時に元の値へ自動復帰

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [ ] CJK ロケール（ja/ko/zh）で住所が大→小順に表示される
- [ ] Western ロケールで住所が小→大順に表示される（既存動作維持）
- [ ] 作成日時フィールドをタップして `YYYY-MM-DD HH:MM` 形式で編集できる
- [ ] 有効な日時入力で `createdAt` が更新される
- [ ] 不正な日時入力時に元の値に自動復帰する
- [ ] TypeScript コンパイルエラーなし
- [ ] ESLint エラーなし

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面（UI）: レポートエディタ画面（`ReportEditorScreen`）
- 機能: 住所取得（`locationService`）、日時表示/編集
- 影響する層:
  - [x] Free
  - [x] Pro
  - [ ] 両方（上記の通り両方）

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし
  - 補足: 住所は表示順のみ変更。保存済みデータは `address` 文字列として DB に格納済みのため影響なし。新規取得分から適用。
- 移行（migration）が必要:
  - [x] なし

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [x] あり（対象言語: ja, ko, zh → 住所並び順が大→小に変更。他の19言語は既存動作維持）
- 端末/OS差分の懸念:
  - [x] なし

---

## 6. 動作確認（How to test / REQUIRED）

### 6-1. 自動テスト
- [x] pnpm lint（結果：✅）
- [x] pnpm type-check / `npx tsc --noEmit`（結果：✅）
- CI: PR 作成時に自動実行

### 6-2. 手動確認（手順を箇条書き / REQUIRED）

**住所フォーマット:**
1. デバイスの言語設定を日本語にする
2. アプリで新規レポートを作成
3. 位置情報を取得する
4. 住所が「日本, 〒xxx, 都道府県, 市区町村, 番地」の順で表示されることを確認
5. デバイスの言語設定を英語に変更して同じ操作を行い、「番地, 市, 州, 郵便番号, 国」の順になることを確認

**作成日時編集:**
1. 新規レポート作成画面を開く
2. 作成日時フィールドに現在日時が自動入力されていることを確認
3. フィールドをタップし、日時を `2025-01-15 09:30` に変更
4. 他のフィールドをタップ（blur）
5. 変更した日時が保持されていることを確認
6. 不正な値 `2025-02-30 25:00` を入力して blur
7. 元の正しい日時に自動復帰することを確認

### 6-3. 再現手順（バグ修正なら / RECOMMENDED）
- N/A（機能追加）

### 6-4. デバッグ証拠
- N/A（機能追加、パフォーマンス改善ではない）

---

## 7. UI差分（UI変更がある場合 / REQUIRED if UI）
- Before: 作成日時は `<Text>` で読み取り専用表示
- After: 作成日時は `<TextInput>` でタップ編集可能（既存の `styles.input` スタイルを使用、他の入力欄と統一感あり）
- Figma: なし

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] どれも不要（理由: 外部仕様/運用/テスト観点に影響なし。住所は表示順のみ変更、日時編集は既存フィールドの操作性改善のみ）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク（短く）
- 想定リスク: CJK ロケール判定が一部端末で期待通り動作しない可能性
- 検知方法: 日本語端末での手動テスト
- 影響の大きさ:
  - [x] 低（困るが致命傷ではない）— 住所は表示順が変わるだけ、編集可能なので修正可能

### 9-2. ロールバック（戻し方 / REQUIRED）
- 戻し方: この PR を revert
- 影響範囲の切り分け: レポートエディタ画面のみ

---

## 10. セキュリティ / 課金 / 広告（該当時のみ）
- [x] Secrets/キーを直書きしていない
- [x] 個人情報をログ出力していない
- [x] 通信はHTTPS前提で問題ない

---

## 11. リリース影響
- 該当なし（release/hotfix ではない）

---

## 12. PRサイズ（RECOMMENDED）
- 変更行数の感覚:
  - [x] 小（〜200行）— 3ファイル、+45/-12行

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲（UI/機能/データ/Free/Pro）を書いた
- [x] "合否が判定できる" 動作確認を記載した（自動/手動）
- [x] CIが通った（TypeScript + ESLint ✅、GitHub Actions は PR 後に実行）
- [x] docs影響を判定し、必要なら更新した
- [x] リスクとロールバックを書いた

🤖 Generated with [Claude Code](https://claude.com/claude-code)