### PR TITLE
feat: 作成日時をネイティブ DateTimePicker に置換

### DIFF
--- a/app.config.ts
+++ b/app.config.ts
@@ -114,6 +114,11 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     },
   );
 
+  const pluginsWithDatePicker = ensurePlugin(
+    pluginsWithAdMob,
+    '@react-native-community/datetimepicker',
+  );
+
   return {
     ...config,
     name: config.name ?? 'Repolog',
@@ -138,6 +143,6 @@ export default ({ config }: ConfigContext): ExpoConfig => {
       supportsRTL,
       forcesRTL,
     },
-    plugins: pluginsWithAdMob,
+    plugins: pluginsWithDatePicker,
   };
 };

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
     "@react-native-async-storage/async-storage": "^2.2.0",
+    "@react-native-community/datetimepicker": "8.4.4",
     "@react-navigation/bottom-tabs": "^7.4.0",
     "@react-navigation/elements": "^2.6.3",
     "@react-navigation/native": "^7.1.8",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,6 +14,9 @@ importers:
       '@react-native-async-storage/async-storage':
         specifier: ^2.2.0
         version: 2.2.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
+      '@react-native-community/datetimepicker':
+        specifier: 8.4.4
+        version: 8.4.4(expo@54.0.32)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
       '@react-navigation/bottom-tabs':
         specifier: ^7.4.0
         version: 7.8.5(@react-navigation/native@7.1.20(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-safe-area-context@5.6.2(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native-screens@4.16.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
@@ -1519,6 +1522,19 @@ packages:
     resolution: {integrity: sha512-gvRvjR5JAaUZF8tv2Kcq/Gbt3JHwbKFYfmb445rhOj6NUMx3qPLixmDx5pZAyb9at1bYvJ4/eTUipU5aki45xw==}
     peerDependencies:
       react-native: ^0.0.0-0 || >=0.65 <1.0
+
+  '@react-native-community/datetimepicker@8.4.4':
+    resolution: {integrity: sha512-bc4ZixEHxZC9/qf5gbdYvIJiLZ5CLmEsC3j+Yhe1D1KC/3QhaIfGDVdUcid0PdlSoGOSEq4VlB93AWyetEyBSQ==}
+    peerDependencies:
+      expo: '>=52.0.0'
+      react: '*'
+      react-native: '*'
+      react-native-windows: '*'
+    peerDependenciesMeta:
+      expo:
+        optional: true
+      react-native-windows:
+        optional: true
 
   '@react-native/assets-registry@0.81.5':
     resolution: {integrity: sha512-705B6x/5Kxm1RKRvSv0ADYWm5JOnoiQ1ufW7h8uu2E6G9Of/eE6hP/Ivw3U5jI16ERqZxiKQwk34VJbB0niX9w==}
@@ -7895,6 +7911,14 @@ snapshots:
       merge-options: 3.0.4
       react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
 
+  '@react-native-community/datetimepicker@8.4.4(expo@54.0.32)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)':
+    dependencies:
+      invariant: 2.2.4
+      react: 19.1.0
+      react-native: 0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0)
+    optionalDependencies:
+      expo: 54.0.32(@babel/core@7.28.5)(@expo/metro-runtime@6.1.2)(expo-router@6.0.22)(react-native-webview@13.15.0(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+
   '@react-native/assets-registry@0.81.5': {}
 
   '@react-native/babel-plugin-codegen@0.81.5(@babel/core@7.28.5)':
@@ -10501,7 +10525,7 @@ snapshots:
       eslint: 9.39.1
       eslint-import-resolver-typescript: 3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1))(eslint@9.39.1)
       eslint-plugin-expo: 1.0.0(eslint@9.39.1)(typescript@5.9.3)
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1))(eslint@9.39.1))(eslint@9.39.1)
       eslint-plugin-react: 7.37.5(eslint@9.39.1)
       eslint-plugin-react-hooks: 5.2.0(eslint@9.39.1)
       globals: 16.5.0
@@ -10538,7 +10562,7 @@ snapshots:
       tinyglobby: 0.2.15
       unrs-resolver: 1.11.1
     optionalDependencies:
-      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1)
+      eslint-plugin-import: 2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1))(eslint@9.39.1))(eslint@9.39.1)
     transitivePeerDependencies:
       - supports-color
 
@@ -10575,7 +10599,7 @@ snapshots:
       lodash: 4.17.21
       string-natural-compare: 3.0.1
 
-  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1)(eslint@9.39.1):
+  eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint-import-resolver-typescript@3.10.1(eslint-plugin-import@2.32.0(@typescript-eslint/parser@8.46.4(eslint@9.39.1)(typescript@5.9.3))(eslint@9.39.1))(eslint@9.39.1))(eslint@9.39.1):
     dependencies:
       '@rtsao/scc': 1.1.0
       array-includes: 3.1.9

--- a/src/features/pdf/pdfUtils.ts
+++ b/src/features/pdf/pdfUtils.ts
@@ -61,16 +61,6 @@ export const formatDateTime = (iso: string) => {
   return `${year}-${month}-${day} ${hour}:${minute}`;
 };
 
-export const parseDateTimeInput = (text: string): string | null => {
-  const match = text.trim().match(/^(\d{4})-(\d{1,2})-(\d{1,2})\s+(\d{1,2}):(\d{1,2})$/);
-  if (!match) return null;
-  const [, y, m, d, h, min] = match;
-  const date = new Date(Number(y), Number(m) - 1, Number(d), Number(h), Number(min));
-  if (Number.isNaN(date.getTime())) return null;
-  if (date.getFullYear() !== Number(y) || date.getMonth() !== Number(m) - 1 || date.getDate() !== Number(d)) return null;
-  return date.toISOString();
-};
-
 export const splitCommentIntoPages = (comment: string, charsPerPage = 1200) => {
   if (!comment) return [''];
   const chars = Array.from(comment);

--- a/src/features/reports/ReportEditorScreen.tsx
+++ b/src/features/reports/ReportEditorScreen.tsx
@@ -20,6 +20,7 @@ import {
 import { SafeAreaView } from 'react-native-safe-area-context';
 import {
   ArrowLeft,
+  CalendarClock,
   Camera,
   Cloud,
   CloudRain,
@@ -30,6 +31,7 @@ import {
   MapPin,
   Sun,
 } from '@tamagui/lucide-icons';
+import { DateTimePickerAndroid } from '@react-native-community/datetimepicker';
 import type { IconProps } from '@tamagui/helpers-icon';
 
 import type { AddressSource, Photo, Report, WeatherType } from '@/src/types/models';
@@ -46,7 +48,7 @@ import {
   remainingCommentChars,
   splitTagInput,
 } from '@/src/features/reports/reportUtils';
-import { formatDateTime, parseDateTimeInput } from '@/src/features/pdf/pdfUtils';
+import { formatDateTime } from '@/src/features/pdf/pdfUtils';
 import { useSettingsStore } from '@/src/stores/settingsStore';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import { getCurrentLocationWithAddress } from '@/src/services/locationService';
@@ -142,7 +144,6 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
   const [tagInput, setTagInput] = useState('');
   const [weather, setWeather] = useState<WeatherType>('none');
   const [createdAt, setCreatedAt] = useState<string>(new Date().toISOString());
-  const [dateText, setDateText] = useState(() => formatDateTime(new Date().toISOString()));
   const [locationState, setLocationState] = useState<LocationState>(emptyLocation);
   const [locationLoading, setLocationLoading] = useState(false);
   const [undoVisible, setUndoVisible] = useState(false);
@@ -213,19 +214,25 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
     };
   }, [loading, report, reportId]);
 
-  useEffect(() => {
-    setDateText(formatDateTime(createdAt));
+  const handleDatePress = useCallback(() => {
+    DateTimePickerAndroid.open({
+      value: new Date(createdAt),
+      mode: 'date',
+      onChange: (event, selectedDate) => {
+        if (event.type !== 'set' || !selectedDate) return;
+        DateTimePickerAndroid.open({
+          value: selectedDate,
+          mode: 'time',
+          is24Hour: true,
+          onChange: (timeEvent, selectedTime) => {
+            if (timeEvent.type === 'set' && selectedTime) {
+              setCreatedAt(selectedTime.toISOString());
+            }
+          },
+        });
+      },
+    });
   }, [createdAt]);
-
-  const handleDateBlur = useCallback(() => {
-    const parsed = parseDateTimeInput(dateText);
-    if (parsed) {
-      setCreatedAt(parsed);
-      setDateText(formatDateTime(parsed));
-    } else {
-      setDateText(formatDateTime(createdAt));
-    }
-  }, [dateText, createdAt]);
 
   const handleFetchLocation = useCallback(async () => {
     if (!includeLocation || locationLoading) return;
@@ -778,15 +785,13 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
             />
 
             <Text style={[styles.fieldLabel, styles.fieldSpacing, { color: colors.textPrimary }]}>{t.createdAtLabel}</Text>
-            <TextInput
-              style={[styles.input, { color: colors.textPrimary, backgroundColor: colors.surfaceHighlight, borderColor: 'rgba(0, 0, 0, 0)' }]}
-              value={dateText}
-              onChangeText={setDateText}
-              onBlur={handleDateBlur}
-              placeholder="YYYY-MM-DD HH:MM"
-              placeholderTextColor={colors.textPlaceholder}
-              keyboardType="numbers-and-punctuation"
-            />
+            <Pressable
+              onPress={handleDatePress}
+              style={[styles.dateField, { backgroundColor: colors.surfaceHighlight }]}
+            >
+              <Text style={[styles.dateFieldText, { color: colors.textPrimary }]}>{formatDateTime(createdAt)}</Text>
+              <CalendarClock size={16} color={colors.textSecondary} strokeWidth={ICON_STROKE_WIDTH} />
+            </Pressable>
 
             <Text style={[styles.fieldLabel, styles.fieldSpacing, { color: colors.textPrimary }]}>{t.weatherLabel}</Text>
             <View style={styles.weatherRow}>
@@ -1093,6 +1098,18 @@ const styles = StyleSheet.create({
     borderRadius: 8,
     paddingHorizontal: 12,
     paddingVertical: 8,
+    fontSize: 16,
+  },
+  dateField: {
+    minHeight: 36,
+    borderRadius: 8,
+    paddingHorizontal: 12,
+    paddingVertical: 8,
+    flexDirection: 'row',
+    alignItems: 'center',
+    justifyContent: 'space-between',
+  },
+  dateFieldText: {
     fontSize: 16,
   },
   textarea: {


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）

作成日時の編集 UI を TextInput からネイティブ DateTimePicker（Material Design カレンダー/時計ダイアログ）に置換。キーボード入力不要でフォーマットエラーも起きないストレスフリーな UX を実現。

---

## 0. 種別（REQUIRED）
- [ ] fix（バグ修正）
- [x] feat（機能追加）
- [ ] refactor（仕様非変更の整理）

---

## 1. 関連リンク（REQUIRED）
- Issue: #188（本件）
- 前提 PR: #187（TextInput 版の日時編集）
- 参照: product_strategy P1「現場で迷わせない」

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: 現場でキーボードを使わず、カレンダーと時計の直感的な UI で日時を選択できる。入力フォーマットを覚える必要がなく、無効な日付を選択できない。
- 技術的改善: `parseDateTimeInput()` のバリデーションロジックが不要になり、コードがシンプルに。

---

## 3. 変更点（What / REQUIRED）
- `package.json` / `pnpm-lock.yaml`: `@react-native-community/datetimepicker@8.4.4` 追加
- `app.config.ts`: Expo プラグインに `@react-native-community/datetimepicker` 登録
- `src/features/reports/ReportEditorScreen.tsx`:
  - `TextInput` → `Pressable` + `CalendarClock` アイコン（Tamagui lucide-icons）
  - `DateTimePickerAndroid` imperative API で日付→時刻の2段階フロー
  - `dateText` state / `handleDateBlur` / `useEffect` 同期を削除
  - `dateField` / `dateFieldText` スタイル追加
- `src/features/pdf/pdfUtils.ts`: 不要になった `parseDateTimeInput()` を削除

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [ ] 作成日時フィールドにカレンダーアイコンが表示される
- [ ] タップでネイティブ日付ピッカー（Material Design）が開く
- [ ] 日付選択後にネイティブ時刻ピッカー（24時間制）が開く
- [ ] 選択完了後に `createdAt` が更新され画面に反映される
- [ ] キャンセル（戻るボタン）時は元の値が保持される
- [ ] TypeScript コンパイルエラーなし
- [ ] ESLint エラーなし

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面: レポートエディタ画面（`ReportEditorScreen`）
- 影響する層:
  - [x] Free
  - [x] Pro

### 5-2. データ/互換性
- [x] なし（UI のみの変更、データ形式は同一の ISO 文字列）

### 5-3. i18n / 端末差分
- [x] なし（ネイティブピッカーはデバイスのロケール設定に自動追従）

---

## 6. 動作確認（How to test / REQUIRED）

### 6-1. 自動テスト
- [x] `npx tsc --noEmit`（結果：✅）
- [x] `npx eslint`（結果：✅）

### 6-2. 手動確認
1. **新規 APK をビルド・インストール**（ネイティブモジュール追加のため再ビルド必須）
2. 新規レポート作成画面を開く
3. 作成日時フィールドに `CalendarClock` アイコンが表示されていることを確認
4. フィールドをタップ → カレンダー UI が開くことを確認
5. 日付を選択 → 時刻ピッカーが開くことを確認
6. 時刻を選択 → 画面の日時表示が更新されることを確認
7. 再度タップ → キャンセル（戻る）→ 日時が変わらないことを確認

---

## 7. UI差分
- Before: `TextInput`（キーボード入力、`YYYY-MM-DD HH:MM` フォーマット手打ち）
- After: `Pressable` + `CalendarClock` アイコン → ネイティブ Material Design ピッカーダイアログ

---

## 8. Docs影響
- [x] どれも不要（UI 操作方法の変更のみ、仕様/制約/運用に影響なし）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク
- 想定リスク: ネイティブモジュール追加による APK サイズ微増（~100KB 程度）
- 影響の大きさ:
  - [x] 低

### 9-2. ロールバック
- この PR を revert し、#187 の TextInput 版に戻す

---

## 10. セキュリティ
- [x] Secrets/キーを直書きしていない
- [x] 個人情報をログ出力していない

---

## 12. PRサイズ
- [x] 小（〜200行）— 5ファイル、+74/-37行

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲を書いた
- [x] 動作確認を記載した
- [x] CIが通った（TypeScript + ESLint ✅）
- [x] docs影響を判定した
- [x] リスクとロールバックを書いた

🤖 Generated with [Claude Code](https://claude.com/claude-code)