### PR TITLE
feat: prepare for Google Play internal testing (#198)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,10 +13,15 @@ expo-env.d.ts
 .kotlin/
 *.orig.*
 *.jks
+*.keystore
 *.p8
 *.p12
 *.key
 *.mobileprovision
+credentials.json
+
+# Secrets (Google Play API service account keys, etc.)
+secrets/
 
 # Metro
 .metro-health-check*

--- a/app.config.ts
+++ b/app.config.ts
@@ -126,6 +126,10 @@ export default ({ config }: ConfigContext): ExpoConfig => {
     android: {
       ...config.android,
       permissions: nextPermissions,
+      blockedPermissions: [
+        'android.permission.RECORD_AUDIO',
+        'android.permission.SYSTEM_ALERT_WINDOW',
+      ],
     },
     extra: {
       ...config.extra,

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "build:android": "expo prebuild --platform android && cd android && ./gradlew bundleRelease",
     "build:android:apk:local": "npx eas-cli@latest build -p android --profile preview-local-apk --local --output dist/repolog-preview-local.apk",
     "build:android:apk:cloud": "npx eas-cli@latest build -p android --profile preview-cloud-apk",
+    "build:android:aab:local": "npx eas-cli@latest build -p android --profile production --local --output dist/repolog-production.aab",
     "build:android:aab:cloud": "npx eas-cli@latest build -p android --profile production",
     "install:device": "adb install -r \"$(wslpath -w dist/repolog-preview-local.apk)\""
   },


### PR DESCRIPTION
## 0. 種別
- [x] feat（機能追加・拡張）

## 1. 関連リンク
- Closes #198
- ref: `docs/how-to/development/android_build.md`
- ref: `docs/store-listing/data-safety/data-safety-declaration.md`

## 2. 目的（Why）
Google Play Console への内部テストリリースに向けた技術的な準備。
- 不要パーミッション（RECORD_AUDIO, SYSTEM_ALERT_WINDOW）がAABに含まれることを防止
- 署名鍵・認証情報の誤コミットを防止
- ローカルでの無料AABビルドを可能にするスクリプトの追加

## 3. 変更点（What）

### app.config.ts
- `android.blockedPermissions` に `RECORD_AUDIO` と `SYSTEM_ALERT_WINDOW` を追加
- Expo の `tools:node="remove"` 機能で、Manifest Merge 時にこれらのパーミッションが最終APK/AABから除外される

### .gitignore
- `*.keystore` — Android 署名鍵ファイル（`.jks` は既に登録済みだが、`.keystore` 拡張子は未登録だった）
- `credentials.json` — EAS Build が一時生成する keystore 参照ファイル
- `secrets/` — Google Play API サービスアカウントキー等の格納ディレクトリ

### package.json
- `build:android:aab:local` スクリプトを追加
- `eas build --local` でクラウドビルド無料枠を消費せず AAB を生成可能

## 4. 受け入れ条件（AC）
- [x] `npx expo prebuild --platform android --clean` 後の AndroidManifest.xml で `RECORD_AUDIO` と `SYSTEM_ALERT_WINDOW` に `tools:node="remove"` が付与されている
- [x] `.gitignore` に `credentials.json`, `*.keystore`, `secrets/` が含まれている
- [x] `pnpm build:android:aab:local` が package.json に定義されている
- [x] CI（lint, test, type-check）がパス

## 5. 影響範囲
- **UI**: 影響なし
- **機能**: 影響なし（パーミッション除外のみ）
- **Free / Pro**: 影響なし
- **i18n**: 影響なし
- **OS差分**: Android のみ

## 6. 動作確認
- [x] `npx expo prebuild --platform android --clean` — `RECORD_AUDIO` と `SYSTEM_ALERT_WINDOW` に `tools:node="remove"` 付与を確認
- [x] `pnpm lint` — 0 errors（3 warnings は既存）
- [x] `pnpm type-check` — パス
- [x] `pnpm test` — 13 suites, 80 tests passed

## 8. Docs影響
- [ ] 追加ドキュメント不要（既存の `android_build.md` の scope 内）

## 9. リスク評価 & ロールバック
- **リスク: 低** — `blockedPermissions` は Expo 公式サポート機能
- **ロールバック**: `blockedPermissions` 配列を削除して `npx expo prebuild --clean` で元に戻る

## 10. セキュリティ/課金/広告
- [x] `.gitignore` に認証情報ファイルパターンを追加（セキュリティ改善）
- [x] 広告: 影響なし（AdMob設定は変更なし）
- [x] 課金: 影響なし

## 12. PRサイズ
- [x] 小（+10行）

## 13. チェックリスト（DoD）
- [x] lint / type-check / test パス
- [x] 不要な `console.log` / デバッグコードなし
- [x] セキュリティ面のレビュー完了

🤖 Generated with [Claude Code](https://claude.com/claude-code)