### PR TITLE
refactor: rename SecureStore pro state key with migration

### DIFF
--- a/src/services/proService.ts
+++ b/src/services/proService.ts
@@ -27,7 +27,8 @@ export type PriceDetails = {
   yearly?: PriceDetail;
 };
 
-const PRO_STATE_KEY = 'dotchain_pro_state_v1';
+const PRO_STATE_KEY = 'repolog_pro_state_v1';
+const LEGACY_PRO_STATE_KEY = 'dotchain_pro_state_v1';
 const ENTITLEMENT_ID = 'Pro_Plan';
 let configured = false;
 
@@ -145,8 +146,16 @@ export const proService = {
   async loadLocalState(): Promise<ProState | null> {
     try {
       const raw = await SecureStore.getItemAsync(PRO_STATE_KEY);
-      if (!raw) return null;
-      return JSON.parse(raw) as ProState;
+      if (raw) return JSON.parse(raw) as ProState;
+
+      // Migrate from legacy key
+      const legacy = await SecureStore.getItemAsync(LEGACY_PRO_STATE_KEY);
+      if (legacy) {
+        await SecureStore.setItemAsync(PRO_STATE_KEY, legacy);
+        await SecureStore.deleteItemAsync(LEGACY_PRO_STATE_KEY);
+        return JSON.parse(legacy) as ProState;
+      }
+      return null;
     } catch {
       return null;
     }


### PR DESCRIPTION
## Summary
- Rename `PRO_STATE_KEY` from `dotchain_pro_state_v1` to `repolog_pro_state_v1` to align with the current app identity
- Add `LEGACY_PRO_STATE_KEY` constant preserving the old key name
- Add transparent migration logic in `loadLocalState()`: if the new key has no data, read from the legacy key, copy to the new key, delete the legacy entry

## Migration logic
On first call to `loadLocalState()` after the update:
1. Try reading from the new key (`repolog_pro_state_v1`) — if found, return immediately
2. If not found, try the legacy key (`dotchain_pro_state_v1`)
3. If legacy data exists, copy it to the new key, delete the legacy entry, and return the state
4. If neither key has data, return `null`

This is a one-time, transparent migration that requires no user action.

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)