### PR TITLE
fix: correct paywall discount, add legal links, suppress cancel alert

### DIFF
--- a/src/core/i18n/locales/en.ts
+++ b/src/core/i18n/locales/en.ts
@@ -36,7 +36,7 @@ const baseEn = {
   paywallBestValueBadge: 'Best value',
   paywallBadgeShort: 'PRO',
   paywallPricePerMonthLabel: 'Price per month',
-  paywallYearlySavings: 'Save ~37% compared with monthly.',
+  paywallYearlySavings: 'Save ~16% compared with monthly.',
   paywallCtaYearly: 'Start Yearly Plan',
   paywallCtaMonthly: 'Start Monthly Plan',
   paywallCtaStayFree: 'Stay Free',

--- a/src/core/i18n/locales/ja.ts
+++ b/src/core/i18n/locales/ja.ts
@@ -18,7 +18,7 @@ const dict = {
     paywallBestValueBadge: 'いちばんおトク',
     paywallBadgeShort: 'PRO',
     paywallPricePerMonthLabel: '1か月あたり',
-    paywallYearlySavings: '月額より約37%おトク',
+    paywallYearlySavings: '月額より約16%おトク',
     paywallCtaYearly: '年額プランでProを始める',
     paywallCtaMonthly: '月額プランでProを試す',
     paywallCtaStayFree: '今は無料で続ける',

--- a/src/core/i18n/locales/pl.ts
+++ b/src/core/i18n/locales/pl.ts
@@ -114,7 +114,7 @@ const dict = {
   paywallBestValueBadge: 'Najlepsza wartość',
   paywallBadgeShort: 'PRO',
   paywallPricePerMonthLabel: 'Cena za miesiąc',
-  paywallYearlySavings: 'Oszczędź ~37% względem planu miesięcznego.',
+  paywallYearlySavings: 'Oszczędź ~16% względem planu miesięcznego.',
   paywallCtaYearly: 'Rozpocznij plan roczny',
   paywallCtaMonthly: 'Rozpocznij plan miesięczny',
   paywallCtaStayFree: 'Pozostań przy Free',

--- a/src/features/pro/PaywallScreen.tsx
+++ b/src/features/pro/PaywallScreen.tsx
@@ -13,6 +13,7 @@ import { useRouter } from 'expo-router';
 import { useAppTheme } from '@/hooks/useAppTheme';
 import { useTranslation } from '@/src/core/i18n/i18n';
 import { proService, type PlanType, type PriceDetails } from '@/src/services/proService';
+import { getLegalLinks, openExternalLink } from '@/src/services/legalService';
 import { useProStore } from '@/src/stores/proStore';
 
 const DEFAULT_BADGE = '#ffb800';
@@ -77,11 +78,24 @@ export default function PaywallScreen() {
       await purchasePro(plan);
       Alert.alert(t.purchaseSuccess);
       router.back();
-    } catch {
+    } catch (e: unknown) {
+      if (e && typeof e === 'object' && 'userCancelled' in e && (e as { userCancelled: boolean }).userCancelled) {
+        return;
+      }
       Alert.alert(t.purchaseFailed);
     } finally {
       setAction(null);
     }
+  };
+
+  const openPrivacyPolicy = () => {
+    const { privacyUrl } = getLegalLinks();
+    void openExternalLink(privacyUrl);
+  };
+
+  const openTerms = () => {
+    const { termsUrl } = getLegalLinks();
+    void openExternalLink(termsUrl);
   };
 
   const handleRestore = async () => {
@@ -185,6 +199,16 @@ export default function PaywallScreen() {
       </View>
 
       <Text style={[styles.finePrint, { color: colors.textMuted }]}>{t.paywallFinePrint}</Text>
+
+      <View style={styles.legalRow}>
+        <Pressable onPress={() => openPrivacyPolicy()}>
+          <Text style={[styles.legalLink, { color: colors.primaryBg }]}>{t.legalPrivacyPolicyLabel}</Text>
+        </Pressable>
+        <Text style={[styles.legalSeparator, { color: colors.textMuted }]}>{'|'}</Text>
+        <Pressable onPress={() => openTerms()}>
+          <Text style={[styles.legalLink, { color: colors.primaryBg }]}>{t.legalTermsOfUseLabel}</Text>
+        </Pressable>
+      </View>
 
       <Pressable onPress={() => router.back()} style={[styles.stayFreeButton, { backgroundColor: colors.surfaceBg, borderColor: colors.borderMedium }]}>
         <Text style={[styles.stayFreeText, { color: colors.textSecondary }]}>{t.paywallCtaStayFree}</Text>
@@ -326,5 +350,18 @@ const styles = StyleSheet.create({
   },
   disabledButton: {
     opacity: 0.5,
+  },
+  legalRow: {
+    flexDirection: 'row',
+    justifyContent: 'center',
+    alignItems: 'center',
+    gap: 8,
+  },
+  legalLink: {
+    fontSize: 12,
+    fontWeight: '500',
+  },
+  legalSeparator: {
+    fontSize: 12,
   },
 });


### PR DESCRIPTION
## Summary
- Fix yearly savings discount rate from ~37% to ~16% across all 19 languages (3 files with explicit overrides: en/ja/pl; other 16 inherit from en.ts)
- Add Privacy Policy and Terms of Use tappable links below the fine print on the Paywall screen
- Suppress the "Purchase failed" error alert when the user intentionally cancels a purchase

## Changes

### 1. Discount rate correction (`paywallYearlySavings`)
Updated `~37%` to `~16%` in:
- `src/core/i18n/locales/en.ts`
- `src/core/i18n/locales/ja.ts`
- `src/core/i18n/locales/pl.ts`

The remaining 16 locale files inherit from `en.ts` via spread (`...baseEn`), so they are automatically corrected.

### 2. Legal links on PaywallScreen
- Imported `getLegalLinks` and `openExternalLink` from `legalService.ts`
- Added `openPrivacyPolicy()` and `openTerms()` helper functions
- Added a `legalRow` View with two Pressable links (Privacy Policy | Terms of Use) below the fine print
- Added `legalRow`, `legalLink`, `legalSeparator` styles

### 3. User cancellation handling
- Changed `catch` to `catch (e: unknown)` in `handlePurchase`
- Added `userCancelled` property check to silently return instead of showing an error alert

## Test plan
- [x] `pnpm lint` — 0 errors (2 pre-existing warnings)
- [x] `pnpm type-check` — passes
- [x] `pnpm test` — 13 suites, 80 tests passed
- [x] `pnpm i18n:check` — 182 used, 0 unused, 0 missing

Closes #202

🤖 Generated with [Claude Code](https://claude.com/claude-code)