### PR TITLE
fix: FABボトムバー重なり修正 + 写真スクロール改善 (#223)

### DIFF
--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -11,7 +11,7 @@ import {
 } from 'react-native';
 import { useFocusEffect, useRouter } from 'expo-router';
 import { Image } from 'expo-image';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 import {
   Cloud,
   CloudRain,
@@ -90,6 +90,7 @@ export default function HomeScreen() {
   const { colors } = useAppTheme();
   const router = useRouter();
   const { t } = useTranslation();
+  const insets = useSafeAreaInsets();
   const isPro = useProStore((s) => s.isPro);
   const proInitialized = useProStore((s) => s.initialized);
   const initPro = useProStore((s) => s.init);
@@ -333,13 +334,13 @@ export default function HomeScreen() {
               data={reports}
               keyExtractor={(item) => item.id}
               renderItem={renderItem}
-              contentContainerStyle={styles.listContent}
+              contentContainerStyle={[styles.listContent, { paddingBottom: 120 + insets.bottom }]}
               showsVerticalScrollIndicator={false}
             />
           )}
 
           {proInitialized && !isPro && (
-            <View style={styles.adBannerWrap}>
+            <View style={[styles.adBannerWrap, { marginBottom: 16 + insets.bottom }]}>
               <AdBanner />
             </View>
           )}
@@ -350,8 +351,8 @@ export default function HomeScreen() {
           accessibilityLabel={t.homeCreateReport}
           accessibilityRole="button"
           onPress={() => router.push('/reports/new')}
-          hitSlop={TOUCH_HIT_SLOP}
-          style={[styles.fabButton, { backgroundColor: colors.primaryBg }]}>
+          hitSlop={{ top: 12, bottom: 12, left: 12, right: 12 }}
+          style={[styles.fabButton, { backgroundColor: colors.primaryBg, bottom: 24 + insets.bottom }]}>
           <Plus size={16} color={colors.textOnPrimary} strokeWidth={ICON_STROKE_WIDTH} />
         </Pressable>
       </View>
@@ -440,7 +441,6 @@ const styles = StyleSheet.create({
     paddingTop: 16,
   },
   listContent: {
-    paddingBottom: 120,
     gap: 16,
   },
   card: {
@@ -521,7 +521,6 @@ const styles = StyleSheet.create({
   },
   adBannerWrap: {
     marginTop: 8,
-    marginBottom: 16,
   },
   emptyState: {
     flex: 1,
@@ -554,7 +553,6 @@ const styles = StyleSheet.create({
   fabButton: {
     position: 'absolute',
     right: 24,
-    bottom: 24,
     width: 56,
     height: 56,
     borderRadius: 28,

--- a/src/features/reports/ReportEditorScreen.tsx
+++ b/src/features/reports/ReportEditorScreen.tsx
@@ -703,7 +703,7 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
                 style={styles.photoDragHandle}
                 accessibilityLabel={t.a11yReorderPhoto}
                 accessibilityRole="button">
-                <GripVertical size={16} color={colors.textMuted} strokeWidth={ICON_STROKE_WIDTH} />
+                <GripVertical size={20} color={colors.textMuted} strokeWidth={ICON_STROKE_WIDTH} />
               </Pressable>
               <Text style={[styles.photoIndexLabel, { color: colors.textSecondary }]}>{index + 1}</Text>
               <View style={styles.photoToolbarSpacer} />
@@ -725,9 +725,7 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
                 <Text style={[styles.photoDeleteButtonText, { color: colors.textPrimary }]}>×</Text>
               </Pressable>
             </View>
-            <Pressable onLongPress={drag} delayLongPress={220} disabled={isActive}>
-              <Image source={{ uri: item.localUri }} style={[styles.photoThumb, { backgroundColor: colors.photoCardBg }]} contentFit="cover" />
-            </Pressable>
+            <Image source={{ uri: item.localUri }} style={[styles.photoThumb, { backgroundColor: colors.photoCardBg }]} contentFit="cover" />
           </View>
         </ScaleDecorator>
       );
@@ -939,7 +937,7 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
                 data={photos}
                 keyExtractor={(item) => item.id}
                 renderItem={renderPhotoItem}
-                activationDistance={8}
+                activationDistance={15}
                 autoscrollThreshold={56}
                 autoscrollSpeed={70}
                 dragItemOverflow={false}
@@ -1214,8 +1212,8 @@ const styles = StyleSheet.create({
     flex: 1,
   },
   photoDragHandle: {
-    width: 36,
-    height: 36,
+    width: 48,
+    height: 48,
     alignItems: 'center',
     justifyContent: 'center',
   },

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -10,7 +10,7 @@ import {
   View,
 } from 'react-native';
 import { useRouter } from 'expo-router';
-import { SafeAreaView } from 'react-native-safe-area-context';
+import { SafeAreaView, useSafeAreaInsets } from 'react-native-safe-area-context';
 
 import { useTranslation, type Lang, type TranslationKey } from '@/src/core/i18n/i18n';
 import { useSettingsStore } from '@/src/stores/settingsStore';
@@ -47,6 +47,7 @@ export default function SettingsScreen() {
   const router = useRouter();
   const { t, lang, setLang } = useTranslation();
   const { colors } = useAppTheme();
+  const insets = useSafeAreaInsets();
   const includeLocation = useSettingsStore((s) => s.includeLocation);
   const setIncludeLocation = useSettingsStore((s) => s.setIncludeLocation);
   const themeMode = useSettingsStore((s) => s.themeMode);
@@ -101,7 +102,7 @@ export default function SettingsScreen() {
 
   return (
     <SafeAreaView style={[styles.safeArea, { backgroundColor: colors.screenBgAlt }]} edges={['top']}>
-      <ScrollView contentContainerStyle={[styles.container, { backgroundColor: colors.screenBgAlt }]} testID="e2e_settings_screen">
+      <ScrollView contentContainerStyle={[styles.container, { backgroundColor: colors.screenBgAlt, paddingBottom: 40 + insets.bottom }]} testID="e2e_settings_screen">
         <View style={styles.headerRow}>
           <Pressable testID="e2e_back_home" accessibilityLabel={t.a11yGoBack} accessibilityRole="button" onPress={() => router.back()} style={[styles.backButton, { borderColor: colors.borderMedium, backgroundColor: colors.surfaceBg }]}>
             <Text style={[styles.backText, { color: colors.textSecondary }]}>{'‹'}</Text>
@@ -251,7 +252,6 @@ const styles = StyleSheet.create({
   },
   container: {
     padding: 16,
-    paddingBottom: 40,
     gap: 16,
   },
   headerRow: {


### PR DESCRIPTION
## Summary
- HomeScreenのFABが`useSafeAreaInsets()`でシステムナビゲーションバーを自動回避するように修正
- レポート編集画面で写真上のスクロールが効かない問題を、写真のPressableラッパー削除で解消
- SettingsScreenのScrollViewも同様にbottom inset対応

## Changes
### `app/(tabs)/index.tsx`
- `useSafeAreaInsets()`フック追加
- FAB: `bottom: 24 + insets.bottom` で動的位置計算
- FlatList: `paddingBottom: 120 + insets.bottom` でリスト末尾のFAB被り防止
- AdBanner: `marginBottom: 16 + insets.bottom` でナビバー被り防止
- FAB hitSlop: 6→12に拡大（手袋対応）

### `src/features/reports/ReportEditorScreen.tsx`
- 写真のPressableラッパー削除（スクロール競合の根本原因）
- `activationDistance`: 8→15（スクロール/ドラッグ判別の閾値拡大）
- ドラッグハンドル: 36→48dp（MD3最小タッチターゲット準拠）
- GripVerticalアイコン: 16→20（屋外視認性向上）

### `src/features/settings/SettingsScreen.tsx`
- `useSafeAreaInsets()`フック追加
- ScrollView `paddingBottom: 40 + insets.bottom` で末尾切れ防止

## Test plan
- [x] `pnpm verify` 全5ゲート通過（lint, type-check, test, i18n:check, config:check）
- [ ] Pixel 8a実機: FABがナビバーに被らない
- [ ] Pixel 8a実機: 写真上でスクロールが正常動作
- [ ] Pixel 8a実機: ドラッグハンドルで写真並べ替え動作
- [ ] Pixel 8a実機: 設定画面の末尾が見切れない

Closes #223

🤖 Generated with [Claude Code](https://claude.com/claude-code)