### PR TITLE
fix: Android戻るジェスチャーでアプリが閉じる問題を修正 (#232)

### DIFF
--- a/app.json
+++ b/app.json
@@ -44,7 +44,7 @@
         "monochromeImage": "./assets/images/android-icon-monochrome.png"
       },
       "edgeToEdgeEnabled": true,
-      "predictiveBackGestureEnabled": true
+      "predictiveBackGestureEnabled": false
     },
     "web": {
       "output": "static",

--- a/docs/reference/tasks/lessons.md
+++ b/docs/reference/tasks/lessons.md
@@ -77,6 +77,19 @@
 
 ---
 
+## Android 戻るジェスチャー
+
+### 2026-03-26: predictiveBackGestureEnabled: true で全画面の戻るジェスチャーがアプリ終了になる
+- **状況**: Android端末で左端スワイプバック（戻るジェスチャー）をすると、前の画面に戻らずアプリが閉じる。全画面で発生
+- **根本原因**: `app.json` の `predictiveBackGestureEnabled: true` が `react-native-screens` v4 未対応の Predictive Back API を有効化。ジェスチャーがJSレイヤーをバイパスし、Activity終了として処理される
+- **1次情報**: expo/expo#39092（OPEN）、react-native-screens Discussion #2540（OPEN）、RN#55211（OPEN）
+- **ルール**:
+  1. `react-native-screens` が Predictive Back を正式サポートするまで `predictiveBackGestureEnabled: false` を維持する
+  2. 非同期処理中にバックで離脱されるリスクがある画面には `BackHandler`（Android）を追加し、カスタム `handleBack` を経由させる
+  3. SDK/ライブラリアップグレード時に expo/expo#39092 の解決状況を確認する
+
+---
+
 ### Claude Code トリガーフレーズ
 - 有効なフレーズ: 「デバッグセッションを分析して」「rebuild して」「Maestro スクショ付きで E2E テストして」
 - 分析時は summary.md → app_logcat.log → screenshots/ の順に読むのが効率的

--- a/src/features/reports/ReportEditorScreen.tsx
+++ b/src/features/reports/ReportEditorScreen.tsx
@@ -2,13 +2,15 @@ import { useCallback, useEffect, useMemo, useRef, useState, type ComponentType }
 import {
   ActivityIndicator,
   Alert,
+  BackHandler,
+  Platform,
   Pressable,
   StyleSheet,
   Text,
   TextInput,
   View,
 } from 'react-native';
-import { useRouter } from 'expo-router';
+import { useFocusEffect, useRouter } from 'expo-router';
 import { Image } from 'expo-image';
 import * as FileSystem from 'expo-file-system/legacy';
 import {
@@ -559,6 +561,17 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
       router.back();
     })();
   }, [finalizePendingDeletion, router]);
+
+  useFocusEffect(
+    useCallback(() => {
+      if (Platform.OS !== 'android') return;
+      const sub = BackHandler.addEventListener('hardwareBackPress', () => {
+        handleBack();
+        return true;
+      });
+      return () => sub.remove();
+    }, [handleBack]),
+  );
 
   const handleAddPhotos = useCallback(
     async (source: 'camera' | 'library') => {


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
Android端末で戻るジェスチャー（左端スワイプ）を行うとアプリが閉じる問題を修正。`predictiveBackGestureEnabled: false` への変更（P0）と、ReportEditorScreenへのBackHandler追加（P1）。

---

## 0. 種別（REQUIRED）
- [x] fix（バグ修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #232
- 参照:
  - 1次情報: expo/expo#39092, software-mansion/react-native-screens Discussion #2540, facebook/react-native#55211
  - constraints: docs/reference/constraints.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: 全画面で戻るジェスチャーが正常に動作し、意図せずアプリが閉じることがなくなる
- バグの再現条件: Android端末でPDFプレビュー等の画面を開き、左端から右にスワイプ → アプリが閉じる

---

## 3. 変更点（What / REQUIRED）
- **P0**: `app.json` の `predictiveBackGestureEnabled` を `true` → `false` に変更（react-native-screens v4未対応のPredictive Back APIを無効化）
- **P1**: `ReportEditorScreen.tsx` に `BackHandler` + `useFocusEffect` を追加（Android戻るボタン/ジェスチャーを既存の `handleBack()` 経由にし、写真削除undo中の状態整合性を保護）
- `lessons.md` にPredictive Back問題のパターンを記録

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] 条件1: 全画面（設定/バックアップ/課金/PDFプレビュー/レポート編集）で左端スワイプバックが前の画面に戻る
- [x] 条件2: ホーム画面でスワイプバックするとアプリが終了する（正常動作）
- [x] 条件3: レポート編集画面でハードウェア戻るボタンが `handleBack()` 経由で動作する（写真削除undoが確定される）

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面（UI）: 全画面（S-01〜S-08）
- 機能: ナビゲーション全般
- 影響する層:
  - [x] 両方

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし
- 移行（migration）が必要:
  - [x] なし

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [x] なし
- 端末/OS差分の懸念:
  - [x] あり（Android専用の修正。iOSには影響なし）

---

## 6. 動作確認（How to test / REQUIRED）

### 6-1. 自動テスト（該当を残す / RECOMMENDED）
- [x] pnpm test（結果：✅ 86 passed）
- [x] pnpm lint（結果：✅ 0 errors）
- [x] pnpm type-check（結果：✅）

### 6-2. 手動確認（手順を箇条書き / REQUIRED）
1. Dev Build APKをビルド・インストール
2. ホーム画面からレポート作成画面を開く
3. 左端からスワイプバック → ホーム画面に戻ることを確認
4. レポート編集 → PDFプレビュー画面を開く
5. 左端からスワイプバック → レポート編集画面に戻ることを確認
6. 設定/バックアップ/課金の各画面で同様に確認
7. レポート編集画面で写真を削除（undoバー表示中に）Androidの戻るボタンを押す → 削除が確定されてホームに戻ることを確認
- 期待結果: 全画面で前の画面に戻る。アプリが閉じない
- 実際結果: ✅

### 6-3. 再現手順（バグ修正なら / RECOMMENDED）
- Before（修正前の再現）: PDFプレビュー画面で左端スワイプ → アプリが閉じる
- After（修正後に再現しない）: PDFプレビュー画面で左端スワイプ → レポート編集画面に戻る

---

## 7. UI差分（UI変更がある場合 / REQUIRED if UI）
UI変更なし

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] どれも不要（理由：外部仕様/運用/テスト観点に影響なし、ネイティブ設定変更のみ）
- lessons.md にパターン記録済み

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク（短く）
- 想定リスク: Predictive Backのプレビューアニメーション（裏の画面チラ見え）が無効化される
- 検知方法: Android端末で戻るジェスチャー時にアニメーションが出ない
- 影響の大きさ:
  - [x] 低（困るが致命傷ではない — アニメーションの有無のみ）

### 9-2. ロールバック（戻し方 / REQUIRED）
- 戻し方: このPRをrevert
- 影響範囲: Android全画面

---

## 10. セキュリティ / 課金 / 広告（該当時のみ / REQUIRED if 該当）
- [x] Secrets/キーを直書きしていない
- [x] 個人情報をログ出力していない
- [x] 通信はHTTPS前提で問題ない

---

## 12. PRサイズ（RECOMMENDED）
- 変更行数の感覚:
  - [x] 小（〜200行）— 3ファイル、28行追加

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲（UI/機能/データ/Free/Pro）を書いた
- [x] "合否が判定できる" 動作確認を記載した（自動/手動）
- [x] CIが通った
- [x] docs影響を判定し、必要なら更新した
- [x] リスクとロールバックを書いた

🤖 Generated with [Claude Code](https://claude.com/claude-code)