### PR TITLE
fix: nvm Node 20 PATH fallback for non-interactive shells (#234)

### DIFF
--- a/docs/reference/tasks/lessons.md
+++ b/docs/reference/tasks/lessons.md
@@ -88,6 +88,14 @@
   2. 非同期処理中にバックで離脱されるリスクがある画面には `BackHandler`（Android）を追加し、カスタム `handleBack` を経由させる
   3. SDK/ライブラリアップグレード時に expo/expo#39092 の解決状況を確認する
 
+### 2026-03-26: 非インタラクティブシェルで nvm Node 20 が PATH に含まれない
+- **状況**: Claude Code の Bash 環境で `node -v` が v18 を返し、EAS ローカルビルドが `toReversed is not a function` で失敗する。`.bashrc` に `nvm use 20` 設定済みだが効かない
+- **根本原因**: nvm.sh は非インタラクティブシェルで PATH を変更しない場合がある。apt インストールの `/usr/bin/node` (v18) が優先される
+- **ルール**:
+  1. `.bashrc` の nvm セクションに「nvm が PATH を変更しなかった場合のフォールバック」を追加する
+  2. `echo "$PATH" | grep -q ".nvm/versions/node"` で nvm PATH の有無を検出し、なければ直接追加
+  3. `.nvmrc` や `engines` フィールドは「警告」であり「強制」ではない。PATH 自体の設定が根本対策
+
 ---
 
 ### Claude Code トリガーフレーズ


### PR DESCRIPTION
# 概要

非インタラクティブシェル（Claude Code等）で nvm の Node 20 が PATH に含まれず、
apt 版 Node 18 が使われる問題の抜本対策。lessons.md にパターンを記録。

---

## 0. 種別（REQUIRED）
- [x] fix（バグ修正）

---

## 1. 関連リンク（REQUIRED）
- Issue: #234

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: EAS ローカルビルドが確実に Node 20 で実行される
- バグの再現条件: Claude Code の Bash で `node -v` → v18.20.8

---

## 3. 変更点（What / REQUIRED）
- `~/.bashrc`: nvm セクションに PATH フォールバック追加（nvm が PATH を変更しなかった場合に直接追加）
- `docs/reference/tasks/lessons.md`: パターン記録

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] `source ~/.bashrc && node -v` が v20 を返す
- [x] lessons.md にパターン記録済み

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 影響する層:
  - [x] 両方

### 5-2. データ/互換性
- [x] なし

### 5-3. i18n / 端末差分
- [x] なし

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト
- CI: lessons.md のみの変更のため、既存テストに影響なし

### 6-2. 手動確認
1. Claude Code の Bash で `node -v` を実行
2. v20.x が返ることを確認

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] どれも不要（理由：システム設定変更、lessons.md 記録のみ）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク
- 想定リスク: なし（PATH に追加するだけ、既存動作に影響しない）
- 影響の大きさ:
  - [x] 低

### 9-2. ロールバック
- 戻し方: `.bashrc` のフォールバックブロックを削除

---

## 12. PRサイズ（RECOMMENDED）
- [x] 小（〜200行）

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲を書いた
- [x] 動作確認を記載した
- [x] CIが通った
- [x] docs影響を判定した
- [x] リスクとロールバックを書いた