### PR TITLE
fix+feat: 住所フォーマット改善 + キーボード表示時ボタンタップ修正 (#238)

### DIFF
--- a/__tests__/locationService.test.ts
+++ b/__tests__/locationService.test.ts
@@ -1,0 +1,154 @@
+// Mock native modules before any imports
+jest.mock('react-native', () => ({
+  Platform: { OS: 'ios' },
+  Keyboard: { dismiss: jest.fn() },
+}));
+
+jest.mock('expo-location', () => ({
+  requestForegroundPermissionsAsync: jest.fn(),
+  getCurrentPositionAsync: jest.fn(),
+  getLastKnownPositionAsync: jest.fn(),
+  reverseGeocodeAsync: jest.fn(),
+  Accuracy: { Balanced: 3 },
+}));
+
+jest.mock('expo-localization', () => ({
+  getLocales: () => [{ languageCode: 'ja', languageTag: 'ja-JP' }],
+}));
+
+jest.mock('localized-address-format', () => ({
+  formatAddress: jest.fn((address: Record<string, unknown>) => {
+    const country = address.postalCountry as string;
+    const postalCode = address.postalCode as string | undefined;
+    const adminArea = address.administrativeArea as string | undefined;
+    const locality = address.locality as string | undefined;
+    const lines = (address.addressLines ?? []) as string[];
+
+    if (country === 'JP') {
+      const parts: string[] = [];
+      if (postalCode) parts.push(`〒${postalCode}`);
+      if (adminArea) parts.push(adminArea);
+      if (locality) parts.push(locality);
+      parts.push(...lines);
+      return parts.length > 0 ? [parts.join('')] : [];
+    }
+
+    if (country === 'US') {
+      const result: string[] = [];
+      if (lines.length > 0) result.push(lines.join(', '));
+      const cityStateLine = [locality, adminArea, postalCode].filter(Boolean).join(', ');
+      if (cityStateLine) result.push(cityStateLine);
+      return result.length > 0 ? result : [];
+    }
+
+    const result: string[] = [];
+    if (lines.length > 0) result.push(lines.join(', '));
+    const rest = [locality, adminArea, postalCode].filter(Boolean).join(', ');
+    if (rest) result.push(rest);
+    return result.length > 0 ? result : [];
+  }),
+}));
+
+import { stripCountryName, formatAddress } from '@/src/services/locationService';
+
+describe('stripCountryName', () => {
+  test('removes leading country with Japanese separator', () => {
+    expect(stripCountryName('日本、〒150-0043 東京都渋谷区', '日本')).toBe(
+      '〒150-0043 東京都渋谷区',
+    );
+  });
+
+  test('removes trailing country with comma', () => {
+    expect(stripCountryName('123 Main St, Springfield, Japan', 'Japan')).toBe(
+      '123 Main St, Springfield',
+    );
+  });
+
+  test('removes leading country with comma-space', () => {
+    expect(stripCountryName('Japan, 150-0043, Tokyo', 'Japan')).toBe('150-0043, Tokyo');
+  });
+
+  test('does not remove country from middle of string', () => {
+    expect(stripCountryName('日本橋1丁目, Tokyo', '日本')).toBe('日本橋1丁目, Tokyo');
+  });
+
+  test('returns original if country is null', () => {
+    expect(stripCountryName('some address', null)).toBe('some address');
+  });
+
+  test('returns original if country is empty', () => {
+    expect(stripCountryName('some address', '')).toBe('some address');
+  });
+
+  test('returns original if no match', () => {
+    expect(stripCountryName('Tokyo, Shibuya', 'Japan')).toBe('Tokyo, Shibuya');
+  });
+});
+
+describe('formatAddress', () => {
+  test('returns null for null/undefined input', () => {
+    expect(formatAddress(null)).toBeNull();
+    expect(formatAddress(undefined)).toBeNull();
+  });
+
+  test('uses localized-address-format for JP on iOS', () => {
+    const geo = {
+      city: '渋谷区',
+      country: '日本',
+      district: null,
+      isoCountryCode: 'JP',
+      name: '道玄坂1丁目',
+      postalCode: '150-0043',
+      region: '東京都',
+      street: '道玄坂',
+      streetNumber: null,
+      subregion: null,
+      timezone: null,
+      formattedAddress: null,
+    };
+    const result = formatAddress(geo as never);
+    expect(result).not.toBeNull();
+    expect(result).toContain('〒150-0043');
+    expect(result).toContain('東京都');
+    expect(result).toContain('渋谷区');
+  });
+
+  test('falls back to legacy format when isoCountryCode is missing', () => {
+    const geo = {
+      city: 'Shibuya',
+      country: 'Japan',
+      district: null,
+      isoCountryCode: null,
+      name: 'Dogenzaka',
+      postalCode: '150-0043',
+      region: 'Tokyo',
+      street: 'Dogenzaka',
+      streetNumber: null,
+      subregion: null,
+      timezone: null,
+      formattedAddress: null,
+    };
+    const result = formatAddress(geo as never);
+    expect(result).not.toBeNull();
+    expect(result).toContain('Japan');
+    expect(result).toContain('Tokyo');
+  });
+
+  test('returns null when all fields are empty', () => {
+    const geo = {
+      city: null,
+      country: null,
+      district: null,
+      isoCountryCode: null,
+      name: null,
+      postalCode: null,
+      region: null,
+      street: null,
+      streetNumber: null,
+      subregion: null,
+      timezone: null,
+      formattedAddress: null,
+    };
+    expect(formatAddress(geo as never)).toBeNull();
+  });
+});

--- a/app/(tabs)/index.tsx
+++ b/app/(tabs)/index.tsx
@@ -328,6 +328,7 @@ export default function HomeScreen() {
               renderItem={renderItem}
               contentContainerStyle={[styles.listContent, { paddingBottom: adSpaceHeight + 80 + insets.bottom }]}
               showsVerticalScrollIndicator={false}
+              keyboardShouldPersistTaps="handled"
             />
           )}
         </View>

--- a/package.json
+++ b/package.json
@@ -70,6 +70,7 @@
     "expo-symbols": "~1.0.8",
     "expo-system-ui": "~6.0.9",
     "expo-web-browser": "~15.0.10",
+    "localized-address-format": "^1.3.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
     "react-native": "0.81.5",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -125,6 +125,9 @@ importers:
       expo-web-browser:
         specifier: ~15.0.10
         version: 15.0.10(expo@54.0.33)(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))
+      localized-address-format:
+        specifier: ^1.3.3
+        version: 1.3.3
       react:
         specifier: 19.1.0
         version: 19.1.0
@@ -4642,6 +4645,9 @@ packages:
 
   lines-and-columns@1.2.4:
     resolution: {integrity: sha512-7ylylesZQ/PV29jhEDl3Ufjo6ZX7gCqJr5F7PKrqc93v7fzSymt1BpwEU8nAUXs8qzzvqhbjhK5QZg6Mt/HkBg==}
+
+  localized-address-format@1.3.3:
+    resolution: {integrity: sha512-oy8YUzVmTQeUYVw9wQEXLf0T2k6WgjTuXc+wMPLzHn+F8WujXczdm0Qm1uY8uAlnZSCjcmGxar3H8tTGWVfdaA==}
 
   locate-path@5.0.0:
     resolution: {integrity: sha512-t7hw9pI+WvuwNJXwk5zVHpyhIqzg2qTlklJOf0mVxGSbe3Fp2VieZcduNYjaLDoy6p9uGpQEGWG87WpMKlNq8g==}
@@ -12242,6 +12248,8 @@ snapshots:
       lightningcss-win32-x64-msvc: 1.30.2
 
   lines-and-columns@1.2.4: {}
+
+  localized-address-format@1.3.3: {}
 
   locate-path@5.0.0:
     dependencies:

--- a/src/features/backup/BackupScreen.tsx
+++ b/src/features/backup/BackupScreen.tsx
@@ -80,7 +80,7 @@ export default function BackupScreen() {
   };
 
   return (
-    <ScrollView testID="e2e_backup_screen" contentContainerStyle={[styles.container, { backgroundColor: colors.screenBgAlt }]}>
+    <ScrollView testID="e2e_backup_screen" contentContainerStyle={[styles.container, { backgroundColor: colors.screenBgAlt }]} keyboardShouldPersistTaps="handled">
       <View style={styles.headerRow}>
         <Pressable testID="e2e_backup_back" onPress={() => router.back()} style={[styles.backButton, { borderColor: colors.borderMedium, backgroundColor: colors.surfaceBg }]}>
           <Text style={[styles.backText, { color: colors.textSecondary }]}>{'‹'}</Text>

--- a/src/features/pro/PaywallScreen.tsx
+++ b/src/features/pro/PaywallScreen.tsx
@@ -155,7 +155,7 @@ export default function PaywallScreen() {
   };
 
   return (
-    <ScrollView contentContainerStyle={[styles.container, { backgroundColor: colors.screenBgAlt }]}>
+    <ScrollView contentContainerStyle={[styles.container, { backgroundColor: colors.screenBgAlt }]} keyboardShouldPersistTaps="handled">
       <View style={styles.headerRow}>
         <Pressable onPress={() => router.back()} style={[styles.backButton, { borderColor: colors.borderMedium, backgroundColor: colors.surfaceBg }]}>
           <Text style={[styles.backText, { color: colors.textSecondary }]}>{'‹'}</Text>

--- a/src/features/reports/ReportEditorScreen.tsx
+++ b/src/features/reports/ReportEditorScreen.tsx
@@ -3,6 +3,7 @@ import {
   ActivityIndicator,
   Alert,
   BackHandler,
+  Keyboard,
   Platform,
   Pressable,
   StyleSheet,
@@ -515,6 +516,7 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
   ]);
 
   const handleSave = async () => {
+    Keyboard.dismiss();
     if (saving) return;
     setSaving(true);
     try {
@@ -789,7 +791,9 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
 
         <Animated.ScrollView
           style={styles.scrollArea}
-          contentContainerStyle={styles.container}>
+          contentContainerStyle={styles.container}
+          keyboardShouldPersistTaps="handled"
+          keyboardDismissMode="on-drag">
           <View style={[styles.section, { backgroundColor: colors.surfaceBg, borderColor: colors.borderDefault }]}>
             <View style={styles.sectionTitleRow}>
               <Text style={[styles.sectionTitle, { color: colors.textHeading }]}>{t.reportBasicInfoSection}</Text>
@@ -960,6 +964,7 @@ export default function ReportEditorScreen({ reportId }: ReportEditorScreenProps
                 keyExtractor={(item) => item.id}
                 renderItem={renderPhotoItem}
                 scrollEnabled={false}
+                keyboardShouldPersistTaps="handled"
                 itemLayoutAnimation={LinearTransition.duration(300)}
                 style={styles.photoStrip}
               />

--- a/src/features/settings/SettingsScreen.tsx
+++ b/src/features/settings/SettingsScreen.tsx
@@ -99,7 +99,7 @@ export default function SettingsScreen() {
 
   return (
     <SafeAreaView style={[styles.safeArea, { backgroundColor: colors.screenBgAlt }]} edges={['top']}>
-      <ScrollView contentContainerStyle={[styles.container, { backgroundColor: colors.screenBgAlt, paddingBottom: 40 + insets.bottom }]} testID="e2e_settings_screen">
+      <ScrollView contentContainerStyle={[styles.container, { backgroundColor: colors.screenBgAlt, paddingBottom: 40 + insets.bottom }]} testID="e2e_settings_screen" keyboardShouldPersistTaps="handled">
         <View style={styles.headerRow}>
           <Pressable testID="e2e_back_home" accessibilityLabel={t.a11yGoBack} accessibilityRole="button" onPress={() => router.back()} style={[styles.backButton, { borderColor: colors.borderMedium, backgroundColor: colors.surfaceBg }]}>
             <Text style={[styles.backText, { color: colors.textSecondary }]}>{'‹'}</Text>

--- a/src/services/locationService.ts
+++ b/src/services/locationService.ts
@@ -1,5 +1,7 @@
 import * as Location from 'expo-location';
 import * as Localization from 'expo-localization';
+import { Platform } from 'react-native';
+import { formatAddress as formatLocalizedAddress } from 'localized-address-format';
 
 import { roundCoordinate } from '@/src/features/reports/reportUtils';
 
@@ -19,16 +21,128 @@ export type LocationResponse =
 
 const CJK_LANGUAGES = new Set(['ja', 'ko', 'zh']);
 
-const formatAddress = (value?: Location.LocationGeocodedAddress | null) => {
-  if (!value) return null;
+/**
+ * Remove country name from the beginning or end of an address string.
+ * Only removes when bounded by a separator (", " or "、" or leading/trailing).
+ */
+export function stripCountryName(address: string, country: string | null): string {
+  if (!country || !address) return address;
+  const trimmed = country.trim();
+  if (!trimmed) return address;
+
+  // Leading: "日本、..." or "Japan, ..."
+  const leadingPatterns = [`${trimmed}、`, `${trimmed}, `, `${trimmed} `];
+  for (const prefix of leadingPatterns) {
+    if (address.startsWith(prefix)) {
+      return address.slice(prefix.length).trim();
+    }
+  }
+
+  // Trailing: "..., Japan" or "...、日本"
+  const trailingPatterns = [`, ${trimmed}`, `、${trimmed}`];
+  for (const suffix of trailingPatterns) {
+    if (address.endsWith(suffix)) {
+      return address.slice(0, -suffix.length).trim();
+    }
+  }
+
+  return address;
+}
+
+/**
+ * Build addressLines from Expo geocode fields.
+ * Combines street, streetNumber, and name while deduplicating overlapping values.
+ */
+function buildAddressLines(geo: Location.LocationGeocodedAddress): string[] {
+  const parts: string[] = [];
+
+  const street = geo.street?.trim() ?? '';
+  const streetNumber = (geo as Record<string, unknown>).streetNumber as string | null;
+  const num = streetNumber?.trim() ?? '';
+  const name = geo.name?.trim() ?? '';
+
+  if (street && num && !street.includes(num)) {
+    parts.push(`${street} ${num}`);
+  } else if (street) {
+    parts.push(street);
+  }
+
+  if (name && name !== street && !street.includes(name) && !name.includes(street)) {
+    parts.push(name);
+  } else if (name && !street) {
+    parts.push(name);
+  }
+
+  return parts;
+}
+
+/**
+ * Format address using localized-address-format library (Google libaddressinput data).
+ * Returns a single-line string or null.
+ */
+function formatWithLibrary(geo: Location.LocationGeocodedAddress): string | null {
+  const countryCode = (geo as Record<string, unknown>).isoCountryCode as string | null;
+  if (!countryCode) return null;
+
+  const lang = Localization.getLocales()?.[0]?.languageCode;
+  const isCjk = lang != null && CJK_LANGUAGES.has(lang);
+  const scriptType = isCjk ? 'local' : 'local';
+
+  const lines = formatLocalizedAddress(
+    {
+      postalCountry: countryCode.toUpperCase(),
+      administrativeArea: geo.region ?? undefined,
+      locality: geo.city ?? undefined,
+      dependentLocality: geo.district ?? undefined,
+      postalCode: geo.postalCode ?? undefined,
+      addressLines: buildAddressLines(geo),
+    },
+    scriptType,
+  );
+
+  if (lines.length === 0) return null;
+
+  const joiner = isCjk ? ' ' : ', ';
+  return lines.join(joiner);
+}
+
+/**
+ * Legacy fallback: comma-separated address parts with CJK-aware ordering.
+ */
+function formatLegacy(geo: Location.LocationGeocodedAddress): string | null {
   const lang = Localization.getLocales()?.[0]?.languageCode;
   const isCjk = lang != null && CJK_LANGUAGES.has(lang);
   const parts = isCjk
-    ? [value.country, value.postalCode, value.region, value.city, value.name, value.street]
-    : [value.street, value.name, value.city, value.region, value.postalCode, value.country];
+    ? [geo.country, geo.postalCode, geo.region, geo.city, geo.name, geo.street]
+    : [geo.street, geo.name, geo.city, geo.region, geo.postalCode, geo.country];
   const filtered = parts.filter((part) => typeof part === 'string' && part.trim().length > 0);
   if (filtered.length === 0) return null;
   return Array.from(new Set(filtered)).join(', ');
+}
+
+/**
+ * Format address with hybrid approach:
+ * 1. Android: use formattedAddress (Google pre-formatted) with country name stripped
+ * 2. localized-address-format library (Google libaddressinput data)
+ * 3. Legacy fallback (comma-separated)
+ */
+export const formatAddress = (value?: Location.LocationGeocodedAddress | null): string | null => {
+  if (!value) return null;
+
+  // Priority 1: Android formattedAddress (pre-formatted by Google Play Services)
+  if (Platform.OS === 'android') {
+    const formatted = (value as Record<string, unknown>).formattedAddress as string | null;
+    if (formatted && formatted.trim().length > 0) {
+      return stripCountryName(formatted.trim(), value.country);
+    }
+  }
+
+  // Priority 2: localized-address-format library
+  const libraryResult = formatWithLibrary(value);
+  if (libraryResult) return libraryResult;
+
+  // Priority 3: Legacy fallback
+  return formatLegacy(value);
 };
 
 export async function getCurrentLocationWithAddress(): Promise<LocationResponse> {


### PR DESCRIPTION
# 概要（1〜3行 / REQUIRED）
テスターフィードバックに基づき、住所の自動入力フォーマットを各国の標準に準拠させ、キーボード表示中のボタンタップが1タップで動作するよう修正。

---

## 0. 種別（REQUIRED）
- [x] fix（バグ修正）
- [x] feat（機能追加）

---

## 1. 関連リンク（REQUIRED）
- Issue: #238
- 参照:
  - functional_spec: docs/reference/functional_spec.md (F-02 住所連動)
  - basic_spec: docs/reference/basic_spec.md

---

## 2. 目的（Why / REQUIRED）
- ユーザー価値: 住所が各国の慣習に沿った自然なフォーマットで表示される。キーボード表示中でもボタンが1タップで反応する。
- バグの再現条件: テキスト入力後、キーボード表示中にScrollView内のボタン（天気・位置情報・写真追加等）をタップ → キーボードが閉じるだけでボタンが反応しない

---

## 3. 変更点（What / REQUIRED）
- `src/services/locationService.ts`: ハイブリッド住所フォーマット（Android formattedAddress優先 → localized-address-format → レガシー）
- `src/features/reports/ReportEditorScreen.tsx`: `keyboardShouldPersistTaps="handled"`, `keyboardDismissMode="on-drag"`, `Keyboard.dismiss()` in handleSave
- `app/(tabs)/index.tsx`: FlatList に `keyboardShouldPersistTaps="handled"`
- `src/features/settings/SettingsScreen.tsx`: ScrollView に `keyboardShouldPersistTaps="handled"`
- `src/features/backup/BackupScreen.tsx`: ScrollView に `keyboardShouldPersistTaps="handled"`
- `src/features/pro/PaywallScreen.tsx`: ScrollView に `keyboardShouldPersistTaps="handled"`
- `__tests__/locationService.test.ts`: 住所フォーマットの Jest テスト追加
- `package.json`: `localized-address-format` 依存追加 (MIT, 0依存, gzip 2.8KB)

---

## 4. 受け入れ条件（Acceptance Criteria / RECOMMENDED）
- [x] AC1: Android で住所が formattedAddress ベースの自然なフォーマットで表示される
- [x] AC2: iOS で localized-address-format による国別フォーマットで表示される
- [x] AC3: キーボード表示中にScrollView内のボタンが1タップで反応する
- [x] AC4: 保存ボタンタップ時にキーボードが閉じる
- [x] AC5: スクロール操作でキーボードが閉じる（on-drag）
- [x] AC6: `pnpm verify` が全て通る（lint 0 errors, test 102 passed, i18n OK, config OK）
- [x] AC7: 住所フォーマットのJestテストが追加されている

---

## 5. 影響範囲（Impact / REQUIRED）
### 5-1. 影響する箇所
- 画面（UI）: S-01 Home, S-02 レポート編集, S-06 Paywall, S-07 設定, バックアップ
- 機能: F-02 レポート編集（住所・位置情報）
- 影響する層:
  - [x] 両方

### 5-2. データ/互換性
- 既存データへの影響:
  - [x] なし
- 移行（migration）が必要:
  - [x] なし

### 5-3. i18n / 端末差分
- 言語/i18n 影響:
  - [x] あり（対象言語: 全19言語 — 住所フォーマットが改善される）
- 端末/OS差分の懸念:
  - [x] あり（Android: formattedAddress優先, iOS: ライブラリフォールバック）

---

## 6. 動作確認（How to test / REQUIRED）
### 6-1. 自動テスト
- [x] pnpm test（結果：✅ 102 passed）
- [x] pnpm lint（結果：✅ 0 errors, 6 warnings — 既存警告のみ）
- [x] pnpm type-check（結果：✅）

### 6-2. 手動確認
1. レポート編集画面を開く
2. テキスト入力欄をタップしてキーボードを表示
3. キーボード表示中に天気アイコン・位置情報ボタン・写真追加ボタンをタップ
- 期待結果: 1タップでボタンが反応する
4. 位置情報を取得し、住所欄のフォーマットを確認
- 期待結果: 国名なし、各国の標準フォーマットで表示される

---

## 7. UI差分（UI変更がある場合 / REQUIRED if UI）
- Before: 住所「日本, 150-0043, 東京都, 渋谷区, 道玄坂」/ ボタン2タップ必要
- After: 住所「〒150-0043 東京都渋谷区道玄坂」/ ボタン1タップで反応

---

## 8. Docs影響（docs-as-code / REQUIRED）
- [x] どれも不要（理由: 外部仕様に影響なし。住所フォーマットは見た目のみの改善、キーボード修正はRN標準プロパティの追加のみ）

---

## 9. リスク評価 & ロールバック（REQUIRED）
### 9-1. リスク
- 想定リスク: 特定の国コードでlocalized-address-formatが空配列を返す可能性
- 検知方法: Jestテスト + 3段階フォールバックで現行ロジックに戻る
- 影響の大きさ:
  - [x] 低（困るが致命傷ではない）

### 9-2. ロールバック
- 戻し方: このPRをrevert
- 影響範囲: 住所表示のみ / 全画面のキーボード操作

---

## 12. PRサイズ（RECOMMENDED）
- [x] 中（〜500行）

---

## 13. チェックリスト（DoD / REQUIRED）
- [x] 変更目的が1文で説明できる
- [x] 影響範囲（UI/機能/データ/Free/Pro）を書いた
- [x] "合否が判定できる" 動作確認を記載した（自動/手動）
- [x] CIが通った
- [x] docs影響を判定し、必要なら更新した
- [x] リスクとロールバックを書いた

🤖 Generated with [Claude Code](https://claude.com/claude-code)