### PR TITLE
fix: バナー広告サイズを INLINE_ADAPTIVE_BANNER + maxHeight=90 に変更 (#240)

### DIFF
--- a/components/ad-banner.tsx
+++ b/components/ad-banner.tsx
@@ -39,7 +39,8 @@ export function AdBanner() {
     <View style={styles.container}>
       <BannerAd
         unitId={unitId}
-        size={BannerAdSize.LARGE_ANCHORED_ADAPTIVE_BANNER}
+        size={BannerAdSize.INLINE_ADAPTIVE_BANNER}
+        maxHeight={90}
         onAdFailedToLoad={handleAdFailedToLoad}
       />
     </View>


### PR DESCRIPTION
## Summary
- Home画面のバナー広告が `LARGE_ANCHORED_ADAPTIVE_BANNER` (最大150dp) で大きすぎた問題を修正
- `INLINE_ADAPTIVE_BANNER` + `maxHeight={90}` に変更し、旧サイズ相当 (最大90dp) に戻す
- adaptive フォーマットを維持するため eCPM への影響を最小化

## Related
- Closes #240
- 関連 PR: #229 (FAB重なり修正時に LARGE_ANCHORED_ADAPTIVE_BANNER に移行)
- 関連 ADR: ADR-0003 (AdMob Banner)

## Changes
| ファイル | 変更内容 |
|---|---|
| `components/ad-banner.tsx` | `LARGE_ANCHORED_ADAPTIVE_BANNER` → `INLINE_ADAPTIVE_BANNER` + `maxHeight={90}` |

## Why
PR #229 で deprecated `ANCHORED_ADAPTIVE_BANNER` → `LARGE_ANCHORED_ADAPTIVE_BANNER` に移行した結果、
バナー最大高さが 90dp → 150dp に増加（67%増）し、Home 画面のコンテンツ領域が圧迫されていた。

Pixel 8a での画面占有率: 22.6% → 13.6% に改善。

## Decision
- `ANCHORED_ADAPTIVE_BANNER` は deprecated (SDK v25.0.0) のため使用しない
- `INLINE_ADAPTIVE_BANNER` は非推奨ではなく、`maxHeight` で高さ上限を制御可能
- 固定サイズ (`BANNER`, `LARGE_BANNER`) は adaptive より eCPM が低いため不採用

## Acceptance Criteria
- [x] `size` が `BannerAdSize.INLINE_ADAPTIVE_BANNER` に変更
- [x] `maxHeight={90}` が設定
- [x] `AD_BANNER_RESERVED_HEIGHT` は 90dp のまま（maxHeight と一致）
- [x] lint / test / type-check 全パス

## Test Evidence
```
lint:       0 errors, 6 warnings (既存、変更と無関係)
test:       15 suites, 102 tests, 全パス
type-check: エラーなし
```

## Risk & Rollback
- **リスク**: INLINE タイプは本来スクロールコンテンツ向けだが、固定配置でも技術的に動作する
- **戻し方**: `size` を `LARGE_ANCHORED_ADAPTIVE_BANNER` に戻し、`maxHeight` を削除

🤖 Generated with [Claude Code](https://claude.com/claude-code)