### PR TITLE
docs: App Store用サポートページ追加 + privacy/terms メール統一

### DIFF
--- a/docs/privacy/index.html
+++ b/docs/privacy/index.html
@@ -38,7 +38,7 @@
   <body>
     <main>
       <h1>Repolog Privacy Policy</h1>
-      <p class="meta">Last updated: February 9, 2026</p>
+      <p class="meta">Last updated: March 27, 2026</p>
 
       <p>
         Repolog is a local-first mobile app for creating photo-based PDF reports.
@@ -67,11 +67,22 @@
 
       <h2>3. Third-party services</h2>
       <ul>
-        <li><strong>RevenueCat:</strong> used for in-app purchase status and restore purchases.</li>
-        <li><strong>Google AdMob:</strong> banner ads for Free plan users only.</li>
+        <li>
+          <strong>RevenueCat:</strong> used for in-app purchase status and restore purchases.
+          RevenueCat may collect a device identifier and purchase history to manage subscriptions.
+          <a href="https://www.revenuecat.com/privacy/">RevenueCat Privacy Policy</a>.
+        </li>
+        <li>
+          <strong>Google AdMob:</strong> banner ads for Free plan users only.
+          AdMob may collect device information, advertising identifiers, and usage data to serve ads.
+          On iOS, you will be asked for permission via the App Tracking Transparency prompt before
+          any tracking-based advertising is enabled.
+          <a href="https://policies.google.com/privacy">Google Privacy Policy</a>.
+        </li>
       </ul>
       <p>
-        These providers may process data according to their own policies.
+        These providers process data according to their own privacy policies linked above.
+        You can opt out of personalized advertising in your device settings.
       </p>
 
       <h2>4. Data sharing</h2>
@@ -100,7 +111,9 @@
 
       <h2>8. Contact</h2>
       <p>
-        For privacy questions, open an issue at
+        For privacy questions, email us at
+        <a href="mailto:doooooraku@gmail.com">doooooraku@gmail.com</a>
+        or open an issue at
         <a href="https://github.com/doooooraku/Repolog/issues">Repolog GitHub Issues</a>.
       </p>
 

--- a/docs/support/index.html
+++ b/docs/support/index.html
@@ -1,0 +1,158 @@
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="UTF-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Repolog Support</title>
+    <style>
+      :root { color-scheme: light; }
+      body {
+        margin: 0;
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Roboto, Helvetica, Arial, sans-serif;
+        background: #f5f7fb;
+        color: #101828;
+      }
+      main {
+        max-width: 860px;
+        margin: 32px auto;
+        background: #fff;
+        border: 1px solid #e4e7ec;
+        border-radius: 16px;
+        padding: 28px;
+      }
+      h1, h2 { margin-top: 0; }
+      h2 { margin-top: 24px; }
+      p, li { line-height: 1.65; }
+      a { color: #155eef; }
+      .meta {
+        color: #475467;
+        margin-bottom: 20px;
+      }
+      .contact-box {
+        background: #f2f4f7;
+        border-radius: 12px;
+        padding: 20px;
+        margin: 16px 0;
+      }
+      .contact-box p { margin: 6px 0; }
+      details {
+        margin-bottom: 12px;
+        border: 1px solid #e4e7ec;
+        border-radius: 8px;
+        padding: 12px 16px;
+      }
+      details summary {
+        cursor: pointer;
+        font-weight: 600;
+      }
+      details p {
+        margin: 8px 0 0;
+      }
+    </style>
+  </head>
+  <body>
+    <main>
+      <h1>Repolog Support</h1>
+      <p class="meta">
+        Repolog &mdash; Photo Report PDF App
+      </p>
+
+      <p>
+        Thank you for using Repolog. If you have questions, issues, or feedback,
+        please reach out using one of the methods below.
+      </p>
+
+      <h2>Contact</h2>
+      <div class="contact-box">
+        <p><strong>Email:</strong> <a href="mailto:doooooraku@gmail.com">doooooraku@gmail.com</a></p>
+        <p><strong>GitHub Issues:</strong> <a href="https://github.com/doooooraku/Repolog/issues">doooooraku/Repolog/issues</a></p>
+      </div>
+      <p>
+        We aim to respond within a few business days.
+      </p>
+
+      <h2>Frequently Asked Questions</h2>
+
+      <details>
+        <summary>How do I create a report?</summary>
+        <p>
+          Tap the + button on the home screen, take photos or pick from your library,
+          add a comment if needed, then tap the PDF button to export your report.
+        </p>
+      </details>
+
+      <details>
+        <summary>Do I need an account to use Repolog?</summary>
+        <p>
+          No. Repolog works without any account or sign-up.
+          All data is stored locally on your device.
+        </p>
+      </details>
+
+      <details>
+        <summary>Where is my data stored?</summary>
+        <p>
+          All reports, photos, and settings are stored on your device only.
+          Repolog does not upload data to the cloud.
+        </p>
+      </details>
+
+      <details>
+        <summary>Can I use Repolog offline?</summary>
+        <p>
+          Yes. You can create reports and export PDFs without an internet connection.
+          Address lookup (reverse geocoding) requires a network connection.
+        </p>
+      </details>
+
+      <details>
+        <summary>How do I restore my Pro purchase?</summary>
+        <p>
+          Go to Settings &gt; Restore Purchases. Make sure you are signed in
+          with the same Apple ID or Google account used for the original purchase.
+        </p>
+      </details>
+
+      <details>
+        <summary>How do I cancel my subscription?</summary>
+        <p>
+          On iOS: Open device Settings &gt; tap your Apple ID &gt; Subscriptions &gt; Repolog &gt; Cancel.<br />
+          On Android: Open Google Play &gt; Payments &amp; subscriptions &gt; Subscriptions &gt; Repolog &gt; Cancel.
+        </p>
+      </details>
+
+      <details>
+        <summary>How do I back up my data?</summary>
+        <p>
+          Go to Settings &gt; Backup &gt; Export. A ZIP file containing all your reports
+          and photos will be created. You can import it on the same or a new device.
+        </p>
+      </details>
+
+      <details>
+        <summary>How do I remove ads?</summary>
+        <p>
+          Upgrade to the Pro plan to remove banner ads and unlock additional features
+          such as unlimited photos and the large PDF layout.
+        </p>
+      </details>
+
+      <details>
+        <summary>What languages are supported?</summary>
+        <p>
+          Repolog supports 19 languages: English, Japanese, French, Spanish, German,
+          Italian, Portuguese, Russian, Chinese (Simplified &amp; Traditional), Korean,
+          Hindi, Indonesian, Thai, Vietnamese, Turkish, Dutch, Polish, and Swedish.
+        </p>
+      </details>
+
+      <h2>Links</h2>
+      <p>
+        Privacy Policy: <a href="/Repolog/privacy/">https://doooooraku.github.io/Repolog/privacy/</a>
+      </p>
+      <p>
+        Terms of Use: <a href="/Repolog/terms/">https://doooooraku.github.io/Repolog/terms/</a>
+      </p>
+    </main>
+  </body>
+</html>

--- a/docs/terms/index.html
+++ b/docs/terms/index.html
@@ -33,7 +33,7 @@
   <body>
     <main>
       <h1>Repolog Terms of Use</h1>
-      <p class="meta">Last updated: February 9, 2026</p>
+      <p class="meta">Last updated: March 27, 2026</p>
 
       <p>
         These Terms of Use govern your use of the Repolog app and related materials.
@@ -62,7 +62,7 @@
 
       <h2>4. Intellectual property</h2>
       <p>
-        The app, branding, and software are owned by Repolog contributors.
+        The app, branding, and software are owned by the developer.
         You retain ownership of the content you create in the app.
       </p>
 
@@ -74,7 +74,7 @@
 
       <h2>6. Limitation of liability</h2>
       <p>
-        To the extent allowed by law, Repolog contributors are not liable for indirect,
+        To the extent allowed by law, the developer is not liable for indirect,
         incidental, or consequential damages arising from app use.
       </p>
 
@@ -89,9 +89,16 @@
         the Apple Standard Licensed Application End User License Agreement may apply.
       </p>
 
-      <h2>9. Contact</h2>
+      <h2>9. Governing law</h2>
       <p>
-        For terms questions, open an issue at
+        These terms are governed by and construed in accordance with the laws of Japan.
+      </p>
+
+      <h2>10. Contact</h2>
+      <p>
+        For questions about these terms, email us at
+        <a href="mailto:doooooraku@gmail.com">doooooraku@gmail.com</a>
+        or open an issue at
         <a href="https://github.com/doooooraku/Repolog/issues">Repolog GitHub Issues</a>.
       </p>
 


### PR DESCRIPTION
## Summary
- `docs/support/index.html` を新規作成（Apple App Store Connect のサポートURL用）
  - 連絡先（メール・GitHub Issues）
  - FAQ 9項目（アコーディオン形式）
  - Privacy Policy / Terms of Use へのリンク
- `docs/privacy/index.html`: メールアドレスを doooooraku@gmail.com に統一、RevenueCat/AdMob のデータ収集詳細・ATT開示を追記
- `docs/terms/index.html`: メールアドレス統一、準拠法（日本法）セクション追加、権利者表記を "the developer" に修正

## Test plan
- [ ] `https://doooooraku.github.io/Repolog/support/` にアクセスしてページが表示されることを確認
- [ ] 連絡先メールリンクが正しく動作することを確認
- [ ] FAQ のアコーディオンが開閉することを確認
- [ ] Privacy Policy / Terms of Use リンクが正しいことを確認
- [ ] モバイル表示でレイアウトが崩れないことを確認

Generated with [Claude Code](https://claude.com/claude-code)