### PR TITLE
feat: iPadサポートを除外し iPhone-only に変更 (#253)

### DIFF
--- a/app.json
+++ b/app.json
@@ -9,7 +9,7 @@
     "userInterfaceStyle": "automatic",
     "newArchEnabled": true,
     "ios": {
-      "supportsTablet": true,
+      "supportsTablet": false,
       "bundleIdentifier": "com.dooooraku.repolog",
       "config": {
         "usesNonExemptEncryption": false


### PR DESCRIPTION
## Summary
- iPadサポートを除外し、v1.0 を iPhone-only でリリースする設定に変更

## Type
- [x] feat（新機能/設定変更）

## Related
- Closes #253

## Purpose & Acceptance Criteria
**目的:** iOS App Store 未公開の今、iPad専用UI/アセット未実装のまま `supportsTablet: true` でリリースすると：
1. iPad上で低品質な体験（iPhone UIの引き伸ばし）→ 低評価リスク
2. Appleルールにより公開後のiPadサポート除外は不可能（不可逆）

**AC:**
- [x] `app.json` の `ios.supportsTablet` が `false`
- [x] prebuild後 `TARGETED_DEVICE_FAMILY = "1"` (iPhone only)
- [x] prebuild後 `Info.plist` に `UISupportedInterfaceOrientations~ipad` なし
- [x] `pnpm verify` 全パス

## Impact Scope
- **UI**: 影響なし（ソースコードにiPad固有ロジックなし）
- **機能**: 影響なし
- **データ**: 影響なし
- **Free/Pro**: 影響なし
- **マイグレーション**: 不要

## Testing Evidence

### pnpm verify 結果
```
✔ ESLint: 0 errors
✔ TypeScript: no errors
✔ Jest: 15 suites, 104 tests passed
✔ i18n:check: 210 keys, 0 missing, 0 unused
✔ config:check: 4/4 passed
```

### iPad設定除去の確認
```bash
$ grep -c "ipad" ios/Repolog/Info.plist
0  # iPad向けキーが完全に除去

$ grep "TARGETED_DEVICE_FAMILY" ios/Repolog.xcodeproj/project.pbxproj
TARGETED_DEVICE_FAMILY = "1";  # Debug (iPhone only)
TARGETED_DEVICE_FAMILY = "1";  # Release (iPhone only)
```

## Docs Updates
- constraints.md: 変更不要（iPad記載なし）
- ADR: 不要（Issue #253 本文に判断理由を記録済み）

## Risk & Rollback
- **リスク**: 極めて低（未公開アプリの設定変更のみ）
- **戻し方**: `supportsTablet: true` に戻して prebuild するだけ（完全可逆）

## Security/Billing/Ads
- [ ] N/A（セキュリティ・課金・広告への影響なし）

## PR Size
- **small**（app.json の1行変更）

## DoD
- [x] `pnpm verify` 全パス
- [x] prebuild後のネイティブファイルでiPad設定除去を確認
- [x] コミットメッセージが規約に準拠

🤖 Generated with [Claude Code](https://claude.com/claude-code)
