### PR TITLE
feat: iOS TestFlight ビルド＆提出ワークフロー追加 (#255)

### DIFF
--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -1,0 +1,77 @@
+name: Build iOS & Submit to TestFlight
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: read
+
+jobs:
+  build-and-submit:
+    name: Build & Submit IPA
+    runs-on: macos-latest
+    timeout-minutes: 60
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@34e114876b0b11c390a56381ad16ebd13914f8d5 # v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@41ff72655975bd51cab0327fa583b6e92b6d3061 # v4
+        with:
+          version: "10"
+
+      - name: Setup Node.js
+        uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020 # v4
+        with:
+          node-version: "20"
+          cache: "pnpm"
+
+      - name: Install EAS CLI
+        run: npm install -g eas-cli
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Create .env file
+        run: |
+          cat <<'DOTENV' > .env
+          ADMOB_IOS_APP_ID=${{ secrets.ADMOB_IOS_APP_ID }}
+          ADMOB_IOS_BANNER_ID=${{ secrets.ADMOB_IOS_BANNER_ID }}
+          REVENUECAT_IOS_API_KEY=${{ secrets.REVENUECAT_IOS_API_KEY }}
+          DOTENV
+
+      - name: Verify code quality
+        run: pnpm verify
+
+      - name: Build iOS IPA
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: eas build --platform ios --profile production --local --non-interactive --output=Repolog.ipa
+
+      - name: Submit to TestFlight
+        env:
+          EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
+        run: eas submit --platform ios --path Repolog.ipa --profile production --non-interactive --no-wait
+
+      - name: Upload IPA artifact
+        if: always()
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: Repolog-iOS-IPA-${{ github.run_id }}
+          path: Repolog.ipa
+          retention-days: 7
+
+      - name: Post build summary
+        if: success()
+        run: |
+          echo "## iOS Build & Submit Successful" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **IPA**: Repolog.ipa" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Profile**: production" >> "$GITHUB_STEP_SUMMARY"
+          echo "- **Submitted to**: TestFlight" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "App Store Connect → TestFlight で新しいビルドを確認してください" >> "$GITHUB_STEP_SUMMARY"

--- a/eas.json
+++ b/eas.json
@@ -37,6 +37,10 @@
     }
   },
   "submit": {
-    "production": {}
+    "production": {
+      "ios": {
+        "ascAppId": "6760099822"
+      }
+    }
   }
 }


### PR DESCRIPTION
## Summary
- `eas.json` に `submit.production.ios.ascAppId` を追加（TestFlight 提出先の指定）
- `.github/workflows/build-ios-testflight.yml` を新規作成（macOS ランナーでの iOS ビルド＆TestFlight 自動提出）

## Type
feat（新機能）

## Related Links
- Closes #255
- 前回の DotChain ワークフロー: `doooooraku/DotChain` の `build-ios-device.yml`

## Purpose
GitHub Actions の macOS ランナーで `.ipa` をローカルビルドし、TestFlight へ自動提出するCI/CDパイプラインを構築する。

## Changes

### eas.json
- `submit.production.ios.ascAppId: "6760099822"` を追加
- EAS Submit が Repolog アプリを識別するために必要

### build-ios-testflight.yml
- **トリガー**: `workflow_dispatch`（手動）+ `v*` タグ push（自動）
- **ランナー**: `macos-latest`（公開リポジトリのため無料）
- **ビルド**: `eas build --local --platform ios`（macOS ランナー上でローカルビルド）
- **提出**: `eas submit --platform ios`（セッションキャッシュ方式）
- **品質チェック**: ビルド前に `pnpm verify` 実行
- **環境変数**: GitHub Secrets から `.env` を生成
- **成果物**: `.ipa` を Artifacts に7日間保存
- **通知**: GitHub Step Summary にビルド結果を出力
- **セキュリティ**: 全 Action を SHA ピン留め

## Acceptance Criteria
- [x] `eas.json` の `submit.production.ios.ascAppId` が設定されている
- [x] ワークフローが SHA ピン留めポリシーに準拠
- [x] `workflow_dispatch` と `push.tags` の両方でトリガー可能
- [x] `.env` が GitHub Secrets から正しく生成される
- [x] ビルド成功時に Step Summary が出力される

## Impact Scope
- CI/CD のみ。アプリのコードに変更なし。

## Test plan
- [ ] `workflow_dispatch` で手動実行し、ビルドが開始されることを確認
- [ ] `.ipa` が Artifacts にアップロードされることを確認
- [ ] TestFlight に提出されることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)