### PR TITLE
fix: iOS TestFlight 提出の ASC API Key 認証エラー修正 (#257)

### DIFF
--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -52,6 +52,11 @@ jobs:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}
         run: eas build --platform ios --profile production --local --non-interactive --output=Repolog.ipa
 
+      - name: Setup ASC API Key
+        run: |
+          mkdir -p secrets
+          echo "${{ secrets.ASC_API_KEY_P8_BASE64 }}" | base64 -d > secrets/AuthKey.p8
+
       - name: Submit to TestFlight
         env:
           EXPO_TOKEN: ${{ secrets.EXPO_TOKEN }}

--- a/eas.json
+++ b/eas.json
@@ -39,7 +39,10 @@
   "submit": {
     "production": {
       "ios": {
-        "ascAppId": "6760099822"
+        "ascAppId": "6760099822",
+        "ascApiKeyId": "6768KZU85A",
+        "ascApiKeyIssuerId": "1f21bf99-fe11-4f44-9827-5b0bfbc3390e",
+        "ascApiKeyPath": "./secrets/AuthKey.p8"
       }
     }
   }


### PR DESCRIPTION
## Summary
- `eas.json` に ASC API Key 認証情報を追加（ascApiKeyId, ascApiKeyIssuerId, ascApiKeyPath）
- ワークフローに `.p8` ファイル復元ステップを追加（GitHub Secret からデコード）

## Type
fix（バグ修正）

## Related Links
- Closes #257
- 関連: #255, PR #256

## Purpose
`eas submit --non-interactive` が App Store Connect API Key を見つけられず失敗するエラーを修正する。

## Changes
- `eas.json`: submit.production.ios に ascApiKeyId, ascApiKeyIssuerId, ascApiKeyPath を追加
- `build-ios-testflight.yml`: Submit 前に GitHub Secret から .p8 をデコード・復元するステップを追加

## Root Cause
`eas credentials --platform ios` で設定した Apple Developer Portal セッションは、`eas submit`（App Store Connect API）の認証には使えない。ASC API Key を明示的に設定する必要がある。

## Test plan
- [ ] `workflow_dispatch` で手動実行し、Submit to TestFlight ステップが成功することを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)