### PR TITLE
feat: Playwright + Sharp によるストアスクリーンショット自動合成

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,8 @@
     "build:android:apk:cloud": "npx eas-cli@latest build -p android --profile preview-cloud-apk",
     "build:android:aab:local": "npx eas-cli@latest build -p android --profile production --local --output dist/repolog-production.aab",
     "build:android:aab:cloud": "npx eas-cli@latest build -p android --profile production",
-    "install:device": "adb install -r \"$(wslpath -w dist/repolog-preview-local.apk)\""
+    "install:device": "adb install -r \"$(wslpath -w dist/repolog-preview-local.apk)\"",
+    "store-screenshots": "npx tsx scripts/store-screenshots/generate.ts"
   },
   "dependencies": {
     "@expo/vector-icons": "^15.0.3",
@@ -108,6 +109,9 @@
     "prettier": "^3.6.2",
     "react-test-renderer": "19.1.0",
     "ts-jest": "^29.4.5",
+    "playwright": "1.52.0",
+    "sharp": "^0.33.0",
+    "tsx": "^4.19.0",
     "typescript": "~5.9.2"
   },
   "jest": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -225,15 +225,24 @@ importers:
       jest-expo:
         specifier: ~54.0.17
         version: 54.0.17(@babel/core@7.28.5)(expo@54.0.33)(jest@29.7.0(@types/node@24.10.1))(react-native@0.81.5(@babel/core@7.28.5)(@types/react@19.1.17)(react@19.1.0))(react@19.1.0)
+      playwright:
+        specifier: 1.52.0
+        version: 1.52.0
       prettier:
         specifier: ^3.6.2
         version: 3.6.2
       react-test-renderer:
         specifier: 19.1.0
         version: 19.1.0(react@19.1.0)
+      sharp:
+        specifier: ^0.33.0
+        version: 0.33.5
       ts-jest:
         specifier: ^29.4.5
         version: 29.4.5(@babel/core@7.28.5)(@jest/transform@30.2.0)(@jest/types@30.2.0)(babel-jest@30.2.0(@babel/core@7.28.5))(esbuild@0.25.12)(jest-util@30.2.0)(jest@29.7.0(@types/node@24.10.1))(typescript@5.9.3)
+      tsx:
+        specifier: ^4.19.0
+        version: 4.21.0
       typescript:
         specifier: ~5.9.2
         version: 5.9.3
@@ -780,8 +789,20 @@ packages:
     cpu: [ppc64]
     os: [aix]
 
+  '@esbuild/aix-ppc64@0.27.4':
+    resolution: {integrity: sha512-cQPwL2mp2nSmHHJlCyoXgHGhbEPMrEEU5xhkcy3Hs/O7nGZqEpZ2sUtLaL9MORLtDfRvVl2/3PAuEkYZH0Ty8Q==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [aix]
+
   '@esbuild/android-arm64@0.25.12':
     resolution: {integrity: sha512-6AAmLG7zwD1Z159jCKPvAxZd4y/VTO0VkprYy+3N2FtJ8+BQWFXU+OxARIwA46c5tdD9SsKGZ/1ocqBS/gAKHg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [android]
+
+  '@esbuild/android-arm64@0.27.4':
+    resolution: {integrity: sha512-gdLscB7v75wRfu7QSm/zg6Rx29VLdy9eTr2t44sfTW7CxwAtQghZ4ZnqHk3/ogz7xao0QAgrkradbBzcqFPasw==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [android]
@@ -792,8 +813,20 @@ packages:
     cpu: [arm]
     os: [android]
 
+  '@esbuild/android-arm@0.27.4':
+    resolution: {integrity: sha512-X9bUgvxiC8CHAGKYufLIHGXPJWnr0OCdR0anD2e21vdvgCI8lIfqFbnoeOz7lBjdrAGUhqLZLcQo6MLhTO2DKQ==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [android]
+
   '@esbuild/android-x64@0.25.12':
     resolution: {integrity: sha512-5jbb+2hhDHx5phYR2By8GTWEzn6I9UqR11Kwf22iKbNpYrsmRB18aX/9ivc5cabcUiAT/wM+YIZ6SG9QO6a8kg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [android]
+
+  '@esbuild/android-x64@0.27.4':
+    resolution: {integrity: sha512-PzPFnBNVF292sfpfhiyiXCGSn9HZg5BcAz+ivBuSsl6Rk4ga1oEXAamhOXRFyMcjwr2DVtm40G65N3GLeH1Lvw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [android]
@@ -804,8 +837,20 @@ packages:
     cpu: [arm64]
     os: [darwin]
 
+  '@esbuild/darwin-arm64@0.27.4':
+    resolution: {integrity: sha512-b7xaGIwdJlht8ZFCvMkpDN6uiSmnxxK56N2GDTMYPr2/gzvfdQN8rTfBsvVKmIVY/X7EM+/hJKEIbbHs9oA4tQ==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [darwin]
+
   '@esbuild/darwin-x64@0.25.12':
     resolution: {integrity: sha512-HQ9ka4Kx21qHXwtlTUVbKJOAnmG1ipXhdWTmNXiPzPfWKpXqASVcWdnf2bnL73wgjNrFXAa3yYvBSd9pzfEIpA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@esbuild/darwin-x64@0.27.4':
+    resolution: {integrity: sha512-sR+OiKLwd15nmCdqpXMnuJ9W2kpy0KigzqScqHI3Hqwr7IXxBp3Yva+yJwoqh7rE8V77tdoheRYataNKL4QrPw==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [darwin]
@@ -816,8 +861,20 @@ packages:
     cpu: [arm64]
     os: [freebsd]
 
+  '@esbuild/freebsd-arm64@0.27.4':
+    resolution: {integrity: sha512-jnfpKe+p79tCnm4GVav68A7tUFeKQwQyLgESwEAUzyxk/TJr4QdGog9sqWNcUbr/bZt/O/HXouspuQDd9JxFSw==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [freebsd]
+
   '@esbuild/freebsd-x64@0.25.12':
     resolution: {integrity: sha512-TGbO26Yw2xsHzxtbVFGEXBFH0FRAP7gtcPE7P5yP7wGy7cXK2oO7RyOhL5NLiqTlBh47XhmIUXuGciXEqYFfBQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@esbuild/freebsd-x64@0.27.4':
+    resolution: {integrity: sha512-2kb4ceA/CpfUrIcTUl1wrP/9ad9Atrp5J94Lq69w7UwOMolPIGrfLSvAKJp0RTvkPPyn6CIWrNy13kyLikZRZQ==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [freebsd]
@@ -828,8 +885,20 @@ packages:
     cpu: [arm64]
     os: [linux]
 
+  '@esbuild/linux-arm64@0.27.4':
+    resolution: {integrity: sha512-7nQOttdzVGth1iz57kxg9uCz57dxQLHWxopL6mYuYthohPKEK0vU0C3O21CcBK6KDlkYVcnDXY099HcCDXd9dA==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [linux]
+
   '@esbuild/linux-arm@0.25.12':
     resolution: {integrity: sha512-lPDGyC1JPDou8kGcywY0YILzWlhhnRjdof3UlcoqYmS9El818LLfJJc3PXXgZHrHCAKs/Z2SeZtDJr5MrkxtOw==}
+    engines: {node: '>=18'}
+    cpu: [arm]
+    os: [linux]
+
+  '@esbuild/linux-arm@0.27.4':
+    resolution: {integrity: sha512-aBYgcIxX/wd5n2ys0yESGeYMGF+pv6g0DhZr3G1ZG4jMfruU9Tl1i2Z+Wnj9/KjGz1lTLCcorqE2viePZqj4Eg==}
     engines: {node: '>=18'}
     cpu: [arm]
     os: [linux]
@@ -840,8 +909,20 @@ packages:
     cpu: [ia32]
     os: [linux]
 
+  '@esbuild/linux-ia32@0.27.4':
+    resolution: {integrity: sha512-oPtixtAIzgvzYcKBQM/qZ3R+9TEUd1aNJQu0HhGyqtx6oS7qTpvjheIWBbes4+qu1bNlo2V4cbkISr8q6gRBFA==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [linux]
+
   '@esbuild/linux-loong64@0.25.12':
     resolution: {integrity: sha512-h///Lr5a9rib/v1GGqXVGzjL4TMvVTv+s1DPoxQdz7l/AYv6LDSxdIwzxkrPW438oUXiDtwM10o9PmwS/6Z0Ng==}
+    engines: {node: '>=18'}
+    cpu: [loong64]
+    os: [linux]
+
+  '@esbuild/linux-loong64@0.27.4':
+    resolution: {integrity: sha512-8mL/vh8qeCoRcFH2nM8wm5uJP+ZcVYGGayMavi8GmRJjuI3g1v6Z7Ni0JJKAJW+m0EtUuARb6Lmp4hMjzCBWzA==}
     engines: {node: '>=18'}
     cpu: [loong64]
     os: [linux]
@@ -852,8 +933,20 @@ packages:
     cpu: [mips64el]
     os: [linux]
 
+  '@esbuild/linux-mips64el@0.27.4':
+    resolution: {integrity: sha512-1RdrWFFiiLIW7LQq9Q2NES+HiD4NyT8Itj9AUeCl0IVCA459WnPhREKgwrpaIfTOe+/2rdntisegiPWn/r/aAw==}
+    engines: {node: '>=18'}
+    cpu: [mips64el]
+    os: [linux]
+
   '@esbuild/linux-ppc64@0.25.12':
     resolution: {integrity: sha512-9meM/lRXxMi5PSUqEXRCtVjEZBGwB7P/D4yT8UG/mwIdze2aV4Vo6U5gD3+RsoHXKkHCfSxZKzmDssVlRj1QQA==}
+    engines: {node: '>=18'}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@esbuild/linux-ppc64@0.27.4':
+    resolution: {integrity: sha512-tLCwNG47l3sd9lpfyx9LAGEGItCUeRCWeAx6x2Jmbav65nAwoPXfewtAdtbtit/pJFLUWOhpv0FpS6GQAmPrHA==}
     engines: {node: '>=18'}
     cpu: [ppc64]
     os: [linux]
@@ -864,8 +957,20 @@ packages:
     cpu: [riscv64]
     os: [linux]
 
+  '@esbuild/linux-riscv64@0.27.4':
+    resolution: {integrity: sha512-BnASypppbUWyqjd1KIpU4AUBiIhVr6YlHx/cnPgqEkNoVOhHg+YiSVxM1RLfiy4t9cAulbRGTNCKOcqHrEQLIw==}
+    engines: {node: '>=18'}
+    cpu: [riscv64]
+    os: [linux]
+
   '@esbuild/linux-s390x@0.25.12':
     resolution: {integrity: sha512-MsKncOcgTNvdtiISc/jZs/Zf8d0cl/t3gYWX8J9ubBnVOwlk65UIEEvgBORTiljloIWnBzLs4qhzPkJcitIzIg==}
+    engines: {node: '>=18'}
+    cpu: [s390x]
+    os: [linux]
+
+  '@esbuild/linux-s390x@0.27.4':
+    resolution: {integrity: sha512-+eUqgb/Z7vxVLezG8bVB9SfBie89gMueS+I0xYh2tJdw3vqA/0ImZJ2ROeWwVJN59ihBeZ7Tu92dF/5dy5FttA==}
     engines: {node: '>=18'}
     cpu: [s390x]
     os: [linux]
@@ -876,8 +981,20 @@ packages:
     cpu: [x64]
     os: [linux]
 
+  '@esbuild/linux-x64@0.27.4':
+    resolution: {integrity: sha512-S5qOXrKV8BQEzJPVxAwnryi2+Iq5pB40gTEIT69BQONqR7JH1EPIcQ/Uiv9mCnn05jff9umq/5nqzxlqTOg9NA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [linux]
+
   '@esbuild/netbsd-arm64@0.25.12':
     resolution: {integrity: sha512-xXwcTq4GhRM7J9A8Gv5boanHhRa/Q9KLVmcyXHCTaM4wKfIpWkdXiMog/KsnxzJ0A1+nD+zoecuzqPmCRyBGjg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [netbsd]
+
+  '@esbuild/netbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-xHT8X4sb0GS8qTqiwzHqpY00C95DPAq7nAwX35Ie/s+LO9830hrMd3oX0ZMKLvy7vsonee73x0lmcdOVXFzd6Q==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [netbsd]
@@ -888,8 +1005,20 @@ packages:
     cpu: [x64]
     os: [netbsd]
 
+  '@esbuild/netbsd-x64@0.27.4':
+    resolution: {integrity: sha512-RugOvOdXfdyi5Tyv40kgQnI0byv66BFgAqjdgtAKqHoZTbTF2QqfQrFwa7cHEORJf6X2ht+l9ABLMP0dnKYsgg==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [netbsd]
+
   '@esbuild/openbsd-arm64@0.25.12':
     resolution: {integrity: sha512-fF96T6KsBo/pkQI950FARU9apGNTSlZGsv1jZBAlcLL1MLjLNIWPBkj5NlSz8aAzYKg+eNqknrUJ24QBybeR5A==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openbsd]
+
+  '@esbuild/openbsd-arm64@0.27.4':
+    resolution: {integrity: sha512-2MyL3IAaTX+1/qP0O1SwskwcwCoOI4kV2IBX1xYnDDqthmq5ArrW94qSIKCAuRraMgPOmG0RDTA74mzYNQA9ow==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openbsd]
@@ -900,8 +1029,20 @@ packages:
     cpu: [x64]
     os: [openbsd]
 
+  '@esbuild/openbsd-x64@0.27.4':
+    resolution: {integrity: sha512-u8fg/jQ5aQDfsnIV6+KwLOf1CmJnfu1ShpwqdwC0uA7ZPwFws55Ngc12vBdeUdnuWoQYx/SOQLGDcdlfXhYmXQ==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [openbsd]
+
   '@esbuild/openharmony-arm64@0.25.12':
     resolution: {integrity: sha512-rm0YWsqUSRrjncSXGA7Zv78Nbnw4XL6/dzr20cyrQf7ZmRcsovpcRBdhD43Nuk3y7XIoW2OxMVvwuRvk9XdASg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@esbuild/openharmony-arm64@0.27.4':
+    resolution: {integrity: sha512-JkTZrl6VbyO8lDQO3yv26nNr2RM2yZzNrNHEsj9bm6dOwwu9OYN28CjzZkH57bh4w0I2F7IodpQvUAEd1mbWXg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [openharmony]
@@ -912,8 +1053,20 @@ packages:
     cpu: [x64]
     os: [sunos]
 
+  '@esbuild/sunos-x64@0.27.4':
+    resolution: {integrity: sha512-/gOzgaewZJfeJTlsWhvUEmUG4tWEY2Spp5M20INYRg2ZKl9QPO3QEEgPeRtLjEWSW8FilRNacPOg8R1uaYkA6g==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [sunos]
+
   '@esbuild/win32-arm64@0.25.12':
     resolution: {integrity: sha512-rMmLrur64A7+DKlnSuwqUdRKyd3UE7oPJZmnljqEptesKM8wx9J8gx5u0+9Pq0fQQW8vqeKebwNXdfOyP+8Bsg==}
+    engines: {node: '>=18'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@esbuild/win32-arm64@0.27.4':
+    resolution: {integrity: sha512-Z9SExBg2y32smoDQdf1HRwHRt6vAHLXcxD2uGgO/v2jK7Y718Ix4ndsbNMU/+1Qiem9OiOdaqitioZwxivhXYg==}
     engines: {node: '>=18'}
     cpu: [arm64]
     os: [win32]
@@ -924,8 +1077,20 @@ packages:
     cpu: [ia32]
     os: [win32]
 
+  '@esbuild/win32-ia32@0.27.4':
+    resolution: {integrity: sha512-DAyGLS0Jz5G5iixEbMHi5KdiApqHBWMGzTtMiJ72ZOLhbu/bzxgAe8Ue8CTS3n3HbIUHQz/L51yMdGMeoxXNJw==}
+    engines: {node: '>=18'}
+    cpu: [ia32]
+    os: [win32]
+
   '@esbuild/win32-x64@0.25.12':
     resolution: {integrity: sha512-alJC0uCZpTFrSL0CCDjcgleBXPnCrEAhTBILpeAp7M/OFgoqtAetfBzX0xM00MUsVVPpVjlPuMbREqnZCXaTnA==}
+    engines: {node: '>=18'}
+    cpu: [x64]
+    os: [win32]
+
+  '@esbuild/win32-x64@0.27.4':
+    resolution: {integrity: sha512-+knoa0BDoeXgkNvvV1vvbZX4+hizelrkwmGJBdT17t8FNPwG2lKemmuMZlmaNQ3ws3DKKCxpb4zRZEIp3UxFCg==}
     engines: {node: '>=18'}
     cpu: [x64]
     os: [win32]
@@ -1132,6 +1297,111 @@ packages:
 
   '@ide/backoff@1.0.0':
     resolution: {integrity: sha512-F0YfUDjvT+Mtt/R4xdl2X0EYCHMMiJqNLdxHD++jDT5ydEFIyqbCHh51Qx2E211dgZprPKhV7sHmnXKpLuvc5g==}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    resolution: {integrity: sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-darwin-x64@0.33.5':
+    resolution: {integrity: sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    resolution: {integrity: sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    resolution: {integrity: sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    resolution: {integrity: sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    resolution: {integrity: sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    resolution: {integrity: sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    resolution: {integrity: sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    resolution: {integrity: sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    resolution: {integrity: sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linux-arm64@0.33.5':
+    resolution: {integrity: sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linux-arm@0.33.5':
+    resolution: {integrity: sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@img/sharp-linux-s390x@0.33.5':
+    resolution: {integrity: sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@img/sharp-linux-x64@0.33.5':
+    resolution: {integrity: sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    resolution: {integrity: sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    resolution: {integrity: sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@img/sharp-wasm32@0.33.5':
+    resolution: {integrity: sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [wasm32]
+
+  '@img/sharp-win32-ia32@0.33.5':
+    resolution: {integrity: sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@img/sharp-win32-x64@0.33.5':
+    resolution: {integrity: sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+    cpu: [x64]
+    os: [win32]
 
   '@isaacs/balanced-match@4.0.1':
     resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
@@ -3270,6 +3540,11 @@ packages:
     engines: {node: '>=18'}
     hasBin: true
 
+  esbuild@0.27.4:
+    resolution: {integrity: sha512-Rq4vbHnYkK5fws5NF7MYTU68FPRE1ajX7heQ/8QXXWqNgqqJ/GkmmyxIzUnf2Sr/bakf8l54716CcMGHYhMrrQ==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   escalade@3.2.0:
     resolution: {integrity: sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==}
     engines: {node: '>=6'}
@@ -3863,6 +4138,11 @@ packages:
 
   fs.realpath@1.0.0:
     resolution: {integrity: sha512-OO0pH2lK6a0hZnAdau5ItzHPI6pUlvI7jMVnxUQRtw4owF2wk8lOSabtGDCTP4Ggrg2MbGnWO9X8K1t4+fGMDw==}
+
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
 
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
@@ -5099,6 +5379,16 @@ packages:
     resolution: {integrity: sha512-HRDzbaKjC+AOWVXxAU/x54COGeIv9eb+6CkDSQoNTt4XyWoIJvuPsXizxu/Fr23EiekbtZwmh1IcIG/l/a10GQ==}
     engines: {node: '>=8'}
 
+  playwright-core@1.52.0:
+    resolution: {integrity: sha512-l2osTgLXSMeuLZOML9qYODUQoPPnUsKsb5/P6LJ2e6uPKXUdPK5WYhN4z03G+YNbWmGDY4YENauNu4ZKczreHg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.52.0:
+    resolution: {integrity: sha512-JAwMNMBlxJ2oD1kce4KPtMkDeKGHQstdpFPcPH3maElAXon/QZeTvtsfXmTMRyO9TslfoYOXkSsvao2nE1ilTw==}
+    engines: {node: '>=18'}
+    hasBin: true
+
   plist@3.1.0:
     resolution: {integrity: sha512-uysumyrvkUX0rX/dEVqt8gC3sTBzd4zoWfLeS29nb53imdaXVvLINYXTI2GNqzaMuvacNx4uJQ8+b3zXR0pkgQ==}
     engines: {node: '>=10.4.0'}
@@ -5578,6 +5868,10 @@ packages:
   shallowequal@1.1.0:
     resolution: {integrity: sha512-y0m1JoUZSlPAjXVtPPW70aZWfIL/dSP7AFkRnniLCrK/8MDKog3TySTBmckD+RObVxH0v4Tox67+F14PdED2oQ==}
 
+  sharp@0.33.5:
+    resolution: {integrity: sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==}
+    engines: {node: ^18.17.0 || ^20.3.0 || >=21.0.0}
+
   shebang-command@2.0.0:
     resolution: {integrity: sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==}
     engines: {node: '>=8'}
@@ -5934,6 +6228,11 @@ packages:
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tsx@4.21.0:
+    resolution: {integrity: sha512-5C1sg4USs1lfG0GFb2RLXsdpXqBSEhAaA/0kPL01wxzpMqLILNxIxIOKiILz+cdg/pLnOUxFYOR5yhHU666wbw==}
+    engines: {node: '>=18.0.0'}
+    hasBin: true
 
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
@@ -6970,79 +7269,157 @@ snapshots:
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
 
+  '@esbuild/aix-ppc64@0.27.4':
+    optional: true
+
   '@esbuild/android-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/android-arm64@0.27.4':
     optional: true
 
   '@esbuild/android-arm@0.25.12':
     optional: true
 
+  '@esbuild/android-arm@0.27.4':
+    optional: true
+
   '@esbuild/android-x64@0.25.12':
+    optional: true
+
+  '@esbuild/android-x64@0.27.4':
     optional: true
 
   '@esbuild/darwin-arm64@0.25.12':
     optional: true
 
+  '@esbuild/darwin-arm64@0.27.4':
+    optional: true
+
   '@esbuild/darwin-x64@0.25.12':
+    optional: true
+
+  '@esbuild/darwin-x64@0.27.4':
     optional: true
 
   '@esbuild/freebsd-arm64@0.25.12':
     optional: true
 
+  '@esbuild/freebsd-arm64@0.27.4':
+    optional: true
+
   '@esbuild/freebsd-x64@0.25.12':
+    optional: true
+
+  '@esbuild/freebsd-x64@0.27.4':
     optional: true
 
   '@esbuild/linux-arm64@0.25.12':
     optional: true
 
+  '@esbuild/linux-arm64@0.27.4':
+    optional: true
+
   '@esbuild/linux-arm@0.25.12':
+    optional: true
+
+  '@esbuild/linux-arm@0.27.4':
     optional: true
 
   '@esbuild/linux-ia32@0.25.12':
     optional: true
 
+  '@esbuild/linux-ia32@0.27.4':
+    optional: true
+
   '@esbuild/linux-loong64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-loong64@0.27.4':
     optional: true
 
   '@esbuild/linux-mips64el@0.25.12':
     optional: true
 
+  '@esbuild/linux-mips64el@0.27.4':
+    optional: true
+
   '@esbuild/linux-ppc64@0.25.12':
+    optional: true
+
+  '@esbuild/linux-ppc64@0.27.4':
     optional: true
 
   '@esbuild/linux-riscv64@0.25.12':
     optional: true
 
+  '@esbuild/linux-riscv64@0.27.4':
+    optional: true
+
   '@esbuild/linux-s390x@0.25.12':
+    optional: true
+
+  '@esbuild/linux-s390x@0.27.4':
     optional: true
 
   '@esbuild/linux-x64@0.25.12':
     optional: true
 
+  '@esbuild/linux-x64@0.27.4':
+    optional: true
+
   '@esbuild/netbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/netbsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/netbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/netbsd-x64@0.27.4':
+    optional: true
+
   '@esbuild/openbsd-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openbsd-arm64@0.27.4':
     optional: true
 
   '@esbuild/openbsd-x64@0.25.12':
     optional: true
 
+  '@esbuild/openbsd-x64@0.27.4':
+    optional: true
+
   '@esbuild/openharmony-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/openharmony-arm64@0.27.4':
     optional: true
 
   '@esbuild/sunos-x64@0.25.12':
     optional: true
 
+  '@esbuild/sunos-x64@0.27.4':
+    optional: true
+
   '@esbuild/win32-arm64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-arm64@0.27.4':
     optional: true
 
   '@esbuild/win32-ia32@0.25.12':
     optional: true
 
+  '@esbuild/win32-ia32@0.27.4':
+    optional: true
+
   '@esbuild/win32-x64@0.25.12':
+    optional: true
+
+  '@esbuild/win32-x64@0.27.4':
     optional: true
 
   '@eslint-community/eslint-utils@4.9.0(eslint@9.39.1)':
@@ -7436,6 +7813,81 @@ snapshots:
   '@iabtcf/core@1.5.6': {}
 
   '@ide/backoff@1.0.0': {}
+
+  '@img/sharp-darwin-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-darwin-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-libvips-darwin-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-darwin-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-arm@1.0.5':
+    optional: true
+
+  '@img/sharp-libvips-linux-s390x@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linux-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-arm64@1.0.4':
+    optional: true
+
+  '@img/sharp-libvips-linuxmusl-x64@1.0.4':
+    optional: true
+
+  '@img/sharp-linux-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-arm@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-arm': 1.0.5
+    optional: true
+
+  '@img/sharp-linux-s390x@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+    optional: true
+
+  '@img/sharp-linux-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linux-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-arm64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+    optional: true
+
+  '@img/sharp-linuxmusl-x64@0.33.5':
+    optionalDependencies:
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+    optional: true
+
+  '@img/sharp-wasm32@0.33.5':
+    dependencies:
+      '@emnapi/runtime': 1.7.1
+    optional: true
+
+  '@img/sharp-win32-ia32@0.33.5':
+    optional: true
+
+  '@img/sharp-win32-x64@0.33.5':
+    optional: true
 
   '@isaacs/balanced-match@4.0.1': {}
 
@@ -10509,6 +10961,35 @@ snapshots:
       '@esbuild/win32-ia32': 0.25.12
       '@esbuild/win32-x64': 0.25.12
 
+  esbuild@0.27.4:
+    optionalDependencies:
+      '@esbuild/aix-ppc64': 0.27.4
+      '@esbuild/android-arm': 0.27.4
+      '@esbuild/android-arm64': 0.27.4
+      '@esbuild/android-x64': 0.27.4
+      '@esbuild/darwin-arm64': 0.27.4
+      '@esbuild/darwin-x64': 0.27.4
+      '@esbuild/freebsd-arm64': 0.27.4
+      '@esbuild/freebsd-x64': 0.27.4
+      '@esbuild/linux-arm': 0.27.4
+      '@esbuild/linux-arm64': 0.27.4
+      '@esbuild/linux-ia32': 0.27.4
+      '@esbuild/linux-loong64': 0.27.4
+      '@esbuild/linux-mips64el': 0.27.4
+      '@esbuild/linux-ppc64': 0.27.4
+      '@esbuild/linux-riscv64': 0.27.4
+      '@esbuild/linux-s390x': 0.27.4
+      '@esbuild/linux-x64': 0.27.4
+      '@esbuild/netbsd-arm64': 0.27.4
+      '@esbuild/netbsd-x64': 0.27.4
+      '@esbuild/openbsd-arm64': 0.27.4
+      '@esbuild/openbsd-x64': 0.27.4
+      '@esbuild/openharmony-arm64': 0.27.4
+      '@esbuild/sunos-x64': 0.27.4
+      '@esbuild/win32-arm64': 0.27.4
+      '@esbuild/win32-ia32': 0.27.4
+      '@esbuild/win32-x64': 0.27.4
+
   escalade@3.2.0: {}
 
   escape-html@1.0.3: {}
@@ -11222,6 +11703,9 @@ snapshots:
       universalify: 2.0.1
 
   fs.realpath@1.0.0: {}
+
+  fsevents@2.3.2:
+    optional: true
 
   fsevents@2.3.3:
     optional: true
@@ -12777,6 +13261,14 @@ snapshots:
     dependencies:
       find-up: 4.1.0
 
+  playwright-core@1.52.0: {}
+
+  playwright@1.52.0:
+    dependencies:
+      playwright-core: 1.52.0
+    optionalDependencies:
+      fsevents: 2.3.2
+
   plist@3.1.0:
     dependencies:
       '@xmldom/xmldom': 0.8.11
@@ -13344,6 +13836,32 @@ snapshots:
 
   shallowequal@1.1.0: {}
 
+  sharp@0.33.5:
+    dependencies:
+      color: 4.2.3
+      detect-libc: 2.1.2
+      semver: 7.7.3
+    optionalDependencies:
+      '@img/sharp-darwin-arm64': 0.33.5
+      '@img/sharp-darwin-x64': 0.33.5
+      '@img/sharp-libvips-darwin-arm64': 1.0.4
+      '@img/sharp-libvips-darwin-x64': 1.0.4
+      '@img/sharp-libvips-linux-arm': 1.0.5
+      '@img/sharp-libvips-linux-arm64': 1.0.4
+      '@img/sharp-libvips-linux-s390x': 1.0.4
+      '@img/sharp-libvips-linux-x64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-arm64': 1.0.4
+      '@img/sharp-libvips-linuxmusl-x64': 1.0.4
+      '@img/sharp-linux-arm': 0.33.5
+      '@img/sharp-linux-arm64': 0.33.5
+      '@img/sharp-linux-s390x': 0.33.5
+      '@img/sharp-linux-x64': 0.33.5
+      '@img/sharp-linuxmusl-arm64': 0.33.5
+      '@img/sharp-linuxmusl-x64': 0.33.5
+      '@img/sharp-wasm32': 0.33.5
+      '@img/sharp-win32-ia32': 0.33.5
+      '@img/sharp-win32-x64': 0.33.5
+
   shebang-command@2.0.0:
     dependencies:
       shebang-regex: 3.0.0
@@ -13770,6 +14288,13 @@ snapshots:
       strip-bom: 3.0.0
 
   tslib@2.8.1: {}
+
+  tsx@4.21.0:
+    dependencies:
+      esbuild: 0.27.4
+      get-tsconfig: 4.13.0
+    optionalDependencies:
+      fsevents: 2.3.3
 
   type-check@0.4.0:
     dependencies:

--- a/scripts/store-screenshots/data/marketing-text.ts
+++ b/scripts/store-screenshots/data/marketing-text.ts
@@ -1,0 +1,162 @@
+/**
+ * Marketing text for Google Play Store screenshot overlays.
+ *
+ * Persona-driven, culturally authentic — NOT machine-translated.
+ * Each phrase uses words the target user (field/construction worker) naturally says.
+ *
+ * Screens:
+ *   1 = Home (report timeline)
+ *   2 = Editor top (basic info, weather, GPS)
+ *   3 = Editor bottom (comments + photos)
+ *   4 = PDF Preview (export)
+ */
+
+export interface MarketingText {
+  locale: string;
+  screen1: string; // Home
+  screen2: string; // Editor top
+  screen3: string; // Editor bottom
+  screen4: string; // PDF Preview
+}
+
+export const marketingTexts: MarketingText[] = [
+  {
+    locale: 'ja',
+    screen1: '現場の記録、スマホにまとまる',
+    screen2: '撮って、書いて、すぐ完成',
+    screen3: '写真もコメントも、まとめて残す',
+    screen4: '提出できるPDF、ワンタップで',
+  },
+  {
+    locale: 'en',
+    screen1: 'All your site reports, one place',
+    screen2: 'Snap, note, done—auto-fills the rest',
+    screen3: 'Photos and notes, kept together',
+    screen4: 'Export a clean PDF in one tap',
+  },
+  {
+    locale: 'fr',
+    screen1: 'Vos rapports de chantier, au m\u00eame endroit',
+    screen2: 'Photo, commentaire, c\u2019est pr\u00eat',
+    screen3: 'Photos et remarques, tout au m\u00eame endroit',
+    screen4: 'Un PDF pro en un seul geste',
+  },
+  {
+    locale: 'es',
+    screen1: 'Tus informes de obra, siempre a mano',
+    screen2: 'Foto, nota, listo—se llena solo',
+    screen3: 'Fotos y observaciones, todo junto',
+    screen4: 'PDF listo para entregar, en un toque',
+  },
+  {
+    locale: 'de',
+    screen1: 'Alle Bauberichte an einem Ort',
+    screen2: 'Foto, Notiz, fertig—Wetter und Ort automatisch',
+    screen3: 'Fotos und Anmerkungen zusammen erfasst',
+    screen4: 'Fertiges PDF mit einem Fingertipp',
+  },
+  {
+    locale: 'it',
+    screen1: 'I tuoi rapporti di cantiere, sempre in ordine',
+    screen2: 'Scatta, annota, fatto—meteo e posizione in automatico',
+    screen3: 'Foto e note di sopralluogo, tutto insieme',
+    screen4: 'PDF pronto da consegnare, con un tap',
+  },
+  {
+    locale: 'pt',
+    screen1: 'Seus relat\u00f3rios de obra, tudo organizado',
+    screen2: 'Fotografou, anotou, pronto—clima e local autom\u00e1ticos',
+    screen3: 'Fotos e anota\u00e7\u00f5es de vistoria, juntas',
+    screen4: 'PDF pronto pra entregar, em um toque',
+  },
+  {
+    locale: 'ru',
+    screen1: '\u0412\u0441\u0435 \u043e\u0442\u0447\u0451\u0442\u044b \u0441 \u043e\u0431\u044a\u0435\u043a\u0442\u0430\u2014\u0432 \u043e\u0434\u043d\u043e\u043c \u043c\u0435\u0441\u0442\u0435',
+    screen2: '\u0421\u0444\u043e\u0442\u043a\u0430\u043b, \u0437\u0430\u043f\u0438\u0441\u0430\u043b\u2014\u043e\u0442\u0447\u0451\u0442 \u0433\u043e\u0442\u043e\u0432',
+    screen3: '\u0424\u043e\u0442\u043e \u0438 \u0437\u0430\u043c\u0435\u0442\u043a\u0438\u2014\u0432\u0441\u0451 \u0432 \u043e\u0434\u043d\u043e\u043c \u043e\u0442\u0447\u0451\u0442\u0435',
+    screen4: '\u0413\u043e\u0442\u043e\u0432\u044b\u0439 PDF \u043e\u0434\u043d\u0438\u043c \u043d\u0430\u0436\u0430\u0442\u0438\u0435\u043c',
+  },
+  {
+    locale: 'zh-Hans',
+    screen1: '\u73b0\u573a\u8bb0\u5f55\uff0c\u4e00\u76ee\u4e86\u7136',
+    screen2: '\u62cd\u7167\u3001\u5907\u6ce8\uff0c\u81ea\u52a8\u586b\u5199',
+    screen3: '\u7167\u7247\u4e0e\u5907\u6ce8\uff0c\u7edf\u4e00\u5f52\u6863',
+    screen4: '\u4e00\u952e\u5bfc\u51fa\uff0c\u63d0\u4ea4\u5c31\u7eea',
+  },
+  {
+    locale: 'zh-Hant',
+    screen1: '\u5de5\u5730\u7d00\u9304\uff0c\u624b\u6a5f\u641e\u5b9a',
+    screen2: '\u62cd\u7167\u3001\u8a3b\u8a18\uff0c\u81ea\u52d5\u5e36\u5165',
+    screen3: '\u7167\u7247\u548c\u8aaa\u660e\uff0c\u6574\u5408\u5728\u4e00\u8d77',
+    screen4: '\u4e00\u9375\u532f\u51fa\uff0c\u96a8\u6642\u63d0\u4ea4',
+  },
+  {
+    locale: 'ko',
+    screen1: '\ud604\uc7a5 \ubcf4\uace0\uc11c, \ud55c\uacf3\uc5d0 \uc815\ub9ac',
+    screen2: '\ucc0d\uace0, \uc4f0\uace0, \ubc14\ub85c \uc644\uc131',
+    screen3: '\uc0ac\uc9c4\uacfc \uba54\ubaa8, \ud568\uaed8 \uae30\ub85d',
+    screen4: '\uc81c\ucd9c\uc6a9 PDF, \uc6d0\ud130\uce58\ub85c \uc644\uc131',
+  },
+  {
+    locale: 'hi',
+    screen1: '\u0938\u093e\u0907\u091f \u0915\u0940 \u0938\u093e\u0930\u0940 \u0930\u093f\u092a\u094b\u0930\u094d\u091f, \u090f\u0915 \u091c\u0917\u0939',
+    screen2: '\u092b\u093c\u094b\u091f\u094b, \u0928\u094b\u091f\u2014\u092c\u093e\u0915\u0940 \u0905\u092a\u0928\u0947 \u0906\u092a \u092d\u0930\u0947',
+    screen3: '\u092b\u093c\u094b\u091f\u094b \u0914\u0930 \u091f\u093f\u092a\u094d\u092a\u0923\u0940, \u0938\u093e\u0925 \u092e\u0947\u0902 \u0938\u0947\u0935',
+    screen4: '\u0924\u0948\u092f\u093e\u0930 PDF, \u092c\u0938 \u090f\u0915 \u091f\u0948\u092a \u092e\u0947\u0902',
+  },
+  {
+    locale: 'id',
+    screen1: 'Semua laporan lapangan, rapi di HP',
+    screen2: 'Foto, catat, langsung jadi',
+    screen3: 'Foto dan catatan, tersimpan lengkap',
+    screen4: 'PDF siap kirim, satu ketukan',
+  },
+  {
+    locale: 'th',
+    screen1: '\u0e23\u0e32\u0e22\u0e07\u0e32\u0e19\u0e2b\u0e19\u0e49\u0e32\u0e07\u0e32\u0e19 \u0e23\u0e27\u0e21\u0e44\u0e27\u0e49\u0e43\u0e19\u0e21\u0e37\u0e2d\u0e16\u0e37\u0e2d',
+    screen2: '\u0e16\u0e48\u0e32\u0e22 \u0e40\u0e02\u0e35\u0e22\u0e19 \u0e40\u0e2a\u0e23\u0e47\u0e08\u0e40\u0e25\u0e22',
+    screen3: '\u0e23\u0e39\u0e1b\u0e41\u0e25\u0e30\u0e1a\u0e31\u0e19\u0e17\u0e36\u0e01 \u0e40\u0e01\u0e47\u0e1a\u0e44\u0e27\u0e49\u0e14\u0e49\u0e27\u0e22\u0e01\u0e31\u0e19',
+    screen4: 'PDF \u0e1e\u0e23\u0e49\u0e2d\u0e21\u0e2a\u0e48\u0e07 \u0e41\u0e04\u0e48\u0e41\u0e15\u0e30\u0e04\u0e23\u0e31\u0e49\u0e07\u0e40\u0e14\u0e35\u0e22\u0e27',
+  },
+  {
+    locale: 'vi',
+    screen1: 'B\u00e1o c\u00e1o hi\u1ec7n tr\u01b0\u1eddng, g\u1ecdn trong \u0111i\u1ec7n tho\u1ea1i',
+    screen2: 'Ch\u1ee5p, ghi ch\u00fa, xong ngay',
+    screen3: '\u1ea2nh v\u00e0 ghi ch\u00fa, l\u01b0u c\u00f9ng m\u1ed9t ch\u1ed7',
+    screen4: 'PDF s\u1eb5n s\u00e0ng n\u1ed9p, ch\u1ec9 m\u1ed9t ch\u1ea1m',
+  },
+  {
+    locale: 'tr',
+    screen1: 'Saha raporlar\u0131n, hepsi bir arada',
+    screen2: '\u00c7ek, yaz, tamam\u2014hava ve konum otomatik',
+    screen3: 'Foto ve notlar, hepsi bir raporda',
+    screen4: 'Teslime haz\u0131r PDF, tek dokunusla',
+  },
+  {
+    locale: 'nl',
+    screen1: 'Al je werkrapporten op \u00e9\u00e9n plek',
+    screen2: 'Foto, notitie, klaar\u2014weer en locatie automatisch',
+    screen3: "Foto's en opmerkingen, alles bij elkaar",
+    screen4: 'Kant-en-klare PDF met \u00e9\u00e9n tik',
+  },
+  {
+    locale: 'pl',
+    screen1: 'Raporty z budowy, wszystko w jednym miejscu',
+    screen2: 'Zdj\u0119cie, notatka, gotowe\u2014pogoda i lokalizacja automatycznie',
+    screen3: 'Zdj\u0119cia i uwagi, razem w raporcie',
+    screen4: 'PDF gotowy do oddania, jednym klikni\u0119ciem',
+  },
+  {
+    locale: 'sv',
+    screen1: 'Alla byggrapporter p\u00e5 ett st\u00e4lle',
+    screen2: 'Fota, anteckna, klart\u2014v\u00e4der och plats fylls i automatiskt',
+    screen3: 'Bilder och anteckningar, samlade',
+    screen4: 'F\u00e4rdig PDF med ett tryck',
+  },
+];
+
+/** Lookup by locale string */
+export const marketingTextMap: Record<string, MarketingText> = {};
+for (const entry of marketingTexts) {
+  marketingTextMap[entry.locale] = entry;
+}

--- a/scripts/store-screenshots/generate.ts
+++ b/scripts/store-screenshots/generate.ts
@@ -1,0 +1,191 @@
+#!/usr/bin/env npx tsx
+/**
+ * Store Screenshot Compositing Generator
+ *
+ * Automates Phase 2 of the store screenshot pipeline:
+ *   raw Maestro screenshots → store-ready composites
+ *   (white background + marketing text + rounded screenshot)
+ *
+ * Usage:
+ *   pnpm store-screenshots                            # all locales, both stores
+ *   pnpm store-screenshots --store apple              # Apple only
+ *   pnpm store-screenshots --store google --lang ja   # Google, Japanese only
+ */
+
+import { parseArgs } from 'node:util';
+import * as fs from 'node:fs/promises';
+import * as path from 'node:path';
+import { chromium } from 'playwright';
+
+import {
+  STORE_SIZES,
+  LOCALE_DIR_MAP,
+  SCREEN_MAP,
+  RAW_DIR,
+  STORE_DIR,
+  type ScreenKey,
+} from './lib/config.js';
+import { cropToBase64 } from './lib/postprocess.js';
+import { flattenAndVerify } from './lib/postprocess.js';
+import { buildFontCss, getFontStack } from './lib/fonts.js';
+import { buildHtml } from './lib/template.js';
+import { renderPage } from './lib/renderer.js';
+import { marketingTextMap } from './data/marketing-text.js';
+
+// ---------------------------------------------------------------------------
+// CLI
+// ---------------------------------------------------------------------------
+
+const { values } = parseArgs({
+  options: {
+    store: { type: 'string', default: 'all' },
+    lang: { type: 'string', default: '' },
+  },
+  strict: true,
+});
+
+const storeNames =
+  values.store === 'all'
+    ? Object.keys(STORE_SIZES)
+    : [values.store!];
+
+const locales = values.lang
+  ? values.lang.split(',').map((s) => s.trim())
+  : Object.keys(LOCALE_DIR_MAP);
+
+// ---------------------------------------------------------------------------
+// Validate inputs
+// ---------------------------------------------------------------------------
+
+for (const store of storeNames) {
+  if (!STORE_SIZES[store]) {
+    console.error(`Unknown store: ${store}. Use "apple", "google", or "all".`);
+    process.exit(1);
+  }
+}
+
+const missingLocales = locales.filter((l) => !LOCALE_DIR_MAP[l]);
+if (missingLocales.length > 0) {
+  console.error(`Unknown locale(s): ${missingLocales.join(', ')}`);
+  process.exit(1);
+}
+
+// Check that raw screenshots exist
+const missingFiles: string[] = [];
+for (const locale of locales) {
+  const dir = LOCALE_DIR_MAP[locale];
+  for (const screen of SCREEN_MAP) {
+    const rawPath = path.join(RAW_DIR, dir, screen.filename);
+    try {
+      await fs.access(rawPath);
+    } catch {
+      missingFiles.push(rawPath);
+    }
+  }
+}
+
+if (missingFiles.length > 0) {
+  console.error(
+    `\n${missingFiles.length} raw screenshot(s) missing:\n` +
+      missingFiles.map((f) => `  - ${f}`).join('\n') +
+      '\n\nRun the Maestro capture scripts first (see docs/how-to/workflow/store_screenshots.md).\n',
+  );
+  process.exit(1);
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+const startTime = Date.now();
+let count = 0;
+let errors = 0;
+
+console.log(
+  `\nGenerating store screenshots...` +
+    `\n  Stores:  ${storeNames.join(', ')}` +
+    `\n  Locales: ${locales.length} (${locales.join(', ')})` +
+    `\n  Screens: ${SCREEN_MAP.length}` +
+    `\n  Total:   ${storeNames.length * locales.length * SCREEN_MAP.length} images\n`,
+);
+
+const browser = await chromium.launch({ headless: true });
+
+try {
+  for (const locale of locales) {
+    const localeDir = LOCALE_DIR_MAP[locale];
+    const text = marketingTextMap[locale];
+    if (!text) {
+      console.error(`  [SKIP] No marketing text for locale: ${locale}`);
+      continue;
+    }
+
+    // Pre-build font CSS once per locale (reused across screens × stores)
+    const fontCss = buildFontCss(locale);
+    const fontStack = getFontStack(locale);
+
+    for (const screen of SCREEN_MAP) {
+      const rawPath = path.join(RAW_DIR, localeDir, screen.filename);
+
+      // Crop once per screen (reused across stores)
+      let croppedBase64: string;
+      try {
+        croppedBase64 = await cropToBase64(rawPath);
+      } catch (err) {
+        console.error(`  [ERROR] Crop failed: ${rawPath}`, err);
+        errors++;
+        continue;
+      }
+
+      const marketingText = text[screen.key as ScreenKey];
+
+      for (const store of storeNames) {
+        const size = STORE_SIZES[store];
+
+        try {
+          // Build HTML
+          const html = buildHtml({
+            marketingText,
+            screenshotBase64: croppedBase64,
+            fontCss,
+            fontStack,
+            locale,
+          });
+
+          // Render
+          const rawPng = await renderPage(browser, html, size);
+
+          // Post-process
+          const finalPng = await flattenAndVerify(rawPng, size.width, size.height);
+
+          // Write
+          const outDir = path.join(STORE_DIR, store, localeDir);
+          await fs.mkdir(outDir, { recursive: true });
+          const outPath = path.join(outDir, screen.filename);
+          await fs.writeFile(outPath, finalPng);
+
+          count++;
+        } catch (err) {
+          console.error(
+            `  [ERROR] ${store}/${localeDir}/${screen.filename}`,
+            err,
+          );
+          errors++;
+        }
+      }
+    }
+
+    console.log(`  ${locale} done`);
+  }
+} finally {
+  await browser.close();
+}
+
+const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+console.log(
+  `\nComplete: ${count} images generated in ${elapsed}s` +
+    (errors > 0 ? ` (${errors} errors)` : '') +
+    `\nOutput:   ${STORE_DIR}/\n`,
+);
+
+if (errors > 0) process.exit(1);

--- a/scripts/store-screenshots/lib/config.ts
+++ b/scripts/store-screenshots/lib/config.ts
@@ -1,0 +1,80 @@
+import * as path from 'node:path';
+
+// ---------------------------------------------------------------------------
+// Store target sizes
+// ---------------------------------------------------------------------------
+
+export interface StoreSize {
+  readonly width: number;
+  readonly height: number;
+}
+
+/** iPhone 6.9" — mandatory for App Store */
+export const APPLE_SIZE: StoreSize = { width: 1320, height: 2868 };
+
+/** Phone — standard for Google Play (9:16) */
+export const GOOGLE_SIZE: StoreSize = { width: 1080, height: 1920 };
+
+export const STORE_SIZES: Record<string, StoreSize> = {
+  apple: APPLE_SIZE,
+  google: GOOGLE_SIZE,
+};
+
+// ---------------------------------------------------------------------------
+// Raw screenshot crop values (Pixel 8a: 1080 x 2400)
+// ---------------------------------------------------------------------------
+
+/** Pixels to remove from top (Android status bar in Demo Mode) */
+export const CROP_TOP = 100;
+
+/** Pixels to remove from bottom (Android gesture bar) */
+export const CROP_BOTTOM = 60;
+
+// ---------------------------------------------------------------------------
+// Screen filename <-> marketing-text key mapping
+// ---------------------------------------------------------------------------
+
+export const SCREEN_MAP = [
+  { key: 'screen1' as const, filename: '01_home.png' },
+  { key: 'screen2' as const, filename: '02_editor_top.png' },
+  { key: 'screen3' as const, filename: '03_editor_bottom.png' },
+  { key: 'screen4' as const, filename: '04_pdf_preview.png' },
+] as const;
+
+export type ScreenKey = (typeof SCREEN_MAP)[number]['key'];
+
+// ---------------------------------------------------------------------------
+// Locale code -> raw screenshot directory name
+// ---------------------------------------------------------------------------
+
+export const LOCALE_DIR_MAP: Record<string, string> = {
+  en: 'en_English',
+  ja: 'ja_日本語',
+  fr: 'fr_Français',
+  es: 'es_Español',
+  de: 'de_Deutsch',
+  it: 'it_Italiano',
+  pt: 'pt_Português',
+  ru: 'ru_Русский',
+  'zh-Hans': 'zh-Hans_简体中文',
+  'zh-Hant': 'zh-Hant_繁體中文',
+  ko: 'ko_한국어',
+  hi: 'hi_हिन्दी',
+  id: 'id_Indonesia',
+  th: 'th_ไทย',
+  vi: 'vi_Tiếng-Việt',
+  tr: 'tr_Türkçe',
+  nl: 'nl_Nederlands',
+  pl: 'pl_Polski',
+  sv: 'sv_Svenska',
+};
+
+// ---------------------------------------------------------------------------
+// Paths
+// ---------------------------------------------------------------------------
+
+const SCRIPTS_DIR = path.resolve(import.meta.dirname, '..');
+export const PROJECT_ROOT = path.resolve(SCRIPTS_DIR, '../..');
+export const RAW_DIR = path.join(PROJECT_ROOT, 'screenshots/raw');
+export const STORE_DIR = path.join(PROJECT_ROOT, 'screenshots/store');
+export const FONTS_DIR = path.join(PROJECT_ROOT, 'assets/fonts');

--- a/scripts/store-screenshots/lib/fonts.ts
+++ b/scripts/store-screenshots/lib/fonts.ts
@@ -1,0 +1,78 @@
+import * as path from 'node:path';
+import { FONTS_DIR } from './config.js';
+
+// ---------------------------------------------------------------------------
+// Font file definitions
+// ---------------------------------------------------------------------------
+
+interface FontDef {
+  /** File name inside assets/fonts/ */
+  file: string;
+  /** CSS font-family name */
+  family: string;
+}
+
+const FONTS: Record<string, FontDef> = {
+  latin: { file: 'NotoSans-Variable.ttf', family: 'Noto Sans' },
+  jp: { file: 'NotoSansJP-Variable.ttf', family: 'Noto Sans JP' },
+  sc: { file: 'NotoSansSC-Variable.ttf', family: 'Noto Sans SC' },
+  tc: { file: 'NotoSansTC-Variable.ttf', family: 'Noto Sans TC' },
+  kr: { file: 'NotoSansKR-Variable.ttf', family: 'Noto Sans KR' },
+  thai: { file: 'NotoSansThai-Variable.ttf', family: 'Noto Sans Thai' },
+  devanagari: {
+    file: 'NotoSansDevanagari-Variable.ttf',
+    family: 'Noto Sans Devanagari',
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Locale -> required font keys
+// ---------------------------------------------------------------------------
+
+const LOCALE_FONTS: Record<string, string[]> = {
+  ja: ['latin', 'jp'],
+  ko: ['latin', 'kr'],
+  'zh-Hans': ['latin', 'sc'],
+  'zh-Hant': ['latin', 'tc'],
+  hi: ['latin', 'devanagari'],
+  th: ['latin', 'thai'],
+};
+
+function getFontKeysForLocale(locale: string): string[] {
+  return LOCALE_FONTS[locale] ?? ['latin'];
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Build @font-face CSS rules for the given locale.
+ * Uses file:// URLs pointing to the existing Variable TTFs in assets/fonts/.
+ */
+export function buildFontCss(locale: string): string {
+  const keys = getFontKeysForLocale(locale);
+  return keys
+    .map((key) => {
+      const font = FONTS[key];
+      const absPath = path.resolve(FONTS_DIR, font.file);
+      return `@font-face {
+  font-family: '${font.family}';
+  src: url('file://${absPath}') format('truetype');
+  font-weight: 100 900;
+  font-display: block;
+}`;
+    })
+    .join('\n');
+}
+
+/**
+ * Return the CSS font-family stack for the given locale.
+ * Script-specific font comes first, then the base Latin font, then sans-serif.
+ */
+export function getFontStack(locale: string): string {
+  const keys = getFontKeysForLocale(locale);
+  const families = keys.map((k) => `'${FONTS[k].family}'`);
+  // Ensure sans-serif fallback is last
+  return [...families, 'sans-serif'].join(', ');
+}

--- a/scripts/store-screenshots/lib/postprocess.ts
+++ b/scripts/store-screenshots/lib/postprocess.ts
@@ -1,0 +1,65 @@
+import sharp from 'sharp';
+import { CROP_TOP, CROP_BOTTOM } from './config.js';
+
+/**
+ * Crop Android status bar (top) and gesture bar (bottom) from a raw
+ * Maestro screenshot, then return the result as a base64 data URI.
+ */
+export async function cropToBase64(rawPath: string): Promise<string> {
+  const meta = await sharp(rawPath).metadata();
+  if (!meta.width || !meta.height) {
+    throw new Error(`Cannot read dimensions of ${rawPath}`);
+  }
+
+  const croppedHeight = meta.height - CROP_TOP - CROP_BOTTOM;
+  if (croppedHeight <= 0) {
+    throw new Error(
+      `Raw image ${rawPath} is too short (${meta.height}px) to crop ${CROP_TOP}+${CROP_BOTTOM}px`,
+    );
+  }
+
+  const buffer = await sharp(rawPath)
+    .extract({
+      left: 0,
+      top: CROP_TOP,
+      width: meta.width,
+      height: croppedHeight,
+    })
+    .png()
+    .toBuffer();
+
+  return `data:image/png;base64,${buffer.toString('base64')}`;
+}
+
+/**
+ * Post-process a Playwright screenshot:
+ *  - Flatten alpha channel (composite onto white)
+ *  - Embed sRGB ICC profile
+ *  - Verify output dimensions
+ *
+ * Returns a 24-bit RGB PNG buffer ready for store submission.
+ */
+export async function flattenAndVerify(
+  pngBuffer: Buffer,
+  expectedWidth: number,
+  expectedHeight: number,
+): Promise<Buffer> {
+  const result = await sharp(pngBuffer)
+    .flatten({ background: '#FFFFFF' })
+    .withIccProfile('srgb')
+    .png({ compressionLevel: 9 })
+    .toBuffer();
+
+  const meta = await sharp(result).metadata();
+  if (meta.width !== expectedWidth || meta.height !== expectedHeight) {
+    throw new Error(
+      `Dimension mismatch: expected ${expectedWidth}x${expectedHeight}, ` +
+        `got ${meta.width}x${meta.height}`,
+    );
+  }
+  if (meta.hasAlpha) {
+    throw new Error('Output still has alpha channel after flattening');
+  }
+
+  return result;
+}

--- a/scripts/store-screenshots/lib/renderer.ts
+++ b/scripts/store-screenshots/lib/renderer.ts
@@ -1,0 +1,43 @@
+import type { Browser } from 'playwright';
+import type { StoreSize } from './config.js';
+
+/**
+ * Render an HTML string at the given viewport size and return the
+ * resulting screenshot as a PNG buffer.
+ *
+ * A fresh page is created and closed for each render to avoid state leakage.
+ * The caller should reuse a single Browser instance across all renders.
+ */
+export async function renderPage(
+  browser: Browser,
+  html: string,
+  size: StoreSize,
+): Promise<Buffer> {
+  const context = await browser.newContext({
+    viewport: { width: size.width, height: size.height },
+    deviceScaleFactor: 1,
+  });
+
+  const page = await context.newPage();
+
+  try {
+    await page.setContent(html, { waitUntil: 'load' });
+
+    // Wait for @font-face fonts to finish loading
+    await page.waitForFunction(() => document.fonts.ready, null, {
+      timeout: 30_000,
+    });
+
+    // Allow shrink-to-fit script + layout reflow to settle
+    await page.waitForTimeout(200);
+
+    const buffer = await page.screenshot({
+      type: 'png',
+      fullPage: false,
+    });
+
+    return Buffer.from(buffer);
+  } finally {
+    await context.close();
+  }
+}

--- a/scripts/store-screenshots/lib/template.ts
+++ b/scripts/store-screenshots/lib/template.ts
@@ -1,0 +1,139 @@
+/**
+ * Build the full HTML document for a single store screenshot composite.
+ *
+ * Layout (top → bottom):
+ *   - White background (#FFF)
+ *   - Marketing text: bold, dark, centered, shrink-to-fit
+ *   - App screenshot: rounded corners, subtle shadow
+ *
+ * All sizes use vh/vw so the same HTML adapts to both
+ * Apple (1320×2868) and Google Play (1080×1920) viewports.
+ */
+
+export interface BuildHtmlOptions {
+  /** Localized marketing text (single line / short phrase) */
+  marketingText: string;
+  /** Cropped screenshot as base64 data URI */
+  screenshotBase64: string;
+  /** @font-face CSS rules from fonts.ts */
+  fontCss: string;
+  /** CSS font-family value from fonts.ts */
+  fontStack: string;
+  /** BCP-47 locale code (e.g. "ja", "zh-Hans") */
+  locale: string;
+}
+
+function escapeHtml(text: string): string {
+  return text
+    .replace(/&/g, '&amp;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .replace(/"/g, '&quot;');
+}
+
+export function buildHtml(opts: BuildHtmlOptions): string {
+  const { marketingText, screenshotBase64, fontCss, fontStack, locale } = opts;
+
+  return `<!DOCTYPE html>
+<html lang="${locale}">
+<head>
+<meta charset="utf-8">
+<style>
+  ${fontCss}
+
+  *, *::before, *::after {
+    margin: 0;
+    padding: 0;
+    box-sizing: border-box;
+  }
+
+  html, body {
+    width: 100vw;
+    height: 100vh;
+    overflow: hidden;
+    background: #FFFFFF;
+    font-family: ${fontStack};
+  }
+
+  .container {
+    width: 100%;
+    height: 100%;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+  }
+
+  /* ---- Marketing text ---- */
+  .text-area {
+    flex-shrink: 0;
+    width: 100%;
+    padding: 5vh 8vw 0 8vw;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    min-height: 12vh;
+    max-height: 18vh;
+  }
+
+  #marketing-text {
+    color: #1A1A1A;
+    font-weight: 700;
+    font-size: 4.5vw;
+    line-height: 1.35;
+    text-align: center;
+    word-break: keep-all;
+    overflow-wrap: break-word;
+  }
+
+  /* ---- Screenshot ---- */
+  .screenshot-area {
+    flex: 1;
+    width: 100%;
+    display: flex;
+    align-items: flex-start;
+    justify-content: center;
+    padding: 2vh 0 3vh 0;
+  }
+
+  .screenshot-area img {
+    height: 78vh;
+    width: auto;
+    max-width: 85vw;
+    border-radius: 2.5vw;
+    object-fit: contain;
+    box-shadow:
+      0 0.3vh 0.8vh rgba(0, 0, 0, 0.06),
+      0 0.8vh 2vh rgba(0, 0, 0, 0.08),
+      0 1.5vh 4vh rgba(0, 0, 0, 0.10);
+  }
+</style>
+</head>
+<body>
+  <div class="container">
+    <div class="text-area">
+      <p id="marketing-text">${escapeHtml(marketingText)}</p>
+    </div>
+    <div class="screenshot-area">
+      <img src="${screenshotBase64}" alt="app screenshot" />
+    </div>
+  </div>
+
+  <script>
+    // Shrink-to-fit: reduce font size until text fits within max-height
+    (function () {
+      var el = document.getElementById('marketing-text');
+      var area = el.parentElement;
+      var maxH = area.clientHeight;
+      var vw = window.innerWidth / 100;
+      var size = 4.5; // vw units
+      el.style.fontSize = size * vw + 'px';
+
+      while (el.scrollHeight > maxH && size > 2.5) {
+        size -= 0.15;
+        el.style.fontSize = size * vw + 'px';
+      }
+    })();
+  </script>
+</body>
+</html>`;
+}


### PR DESCRIPTION
## Summary

- Phase 2（Figma 手作業 14 ステップ × 19 言語 = 6〜8 時間）を Playwright + Sharp で自動化
- コマンド 1 つで Apple App Store (1320×2868) と Google Play (1080×1920) のスクリーンショットを一括生成
- 19 言語 × 4 画面 × 2 ストア = 最大 152 枚を約 2〜4 分で生成

### 新規ファイル
- `generate.ts`: CLI エントリポイント (`--store`, `--lang` フラグ)
- `lib/config.ts`: ストアサイズ・ロケールマッピング・パス定数
- `lib/template.ts`: レスポンシブ HTML テンプレート (vh/vw, shrink-to-fit JS)
- `lib/fonts.ts`: ロケール別 Noto Sans @font-face 生成
- `lib/renderer.ts`: Playwright ヘッドレス描画
- `lib/postprocess.ts`: Sharp クロップ・アルファ除去・sRGB 埋込

### 使い方
```bash
pnpm store-screenshots                          # 全19言語、両ストア
pnpm store-screenshots --store apple --lang ja   # Apple のみ、日本語のみ
```

## Test plan
- [ ] `pnpm store-screenshots --store apple --lang ja` で単一言語テスト
- [ ] 出力画像の目視確認（テキスト、角丸、影、Android バー除去）
- [ ] 全 19 言語バッチ実行で CJK/Thai/Hindi フォント確認
- [ ] `tsc --noEmit` パス確認済み

Closes #268

:robot: Generated with [Claude Code](https://claude.com/claude-code)