### PR TITLE
fix: スクリーンショット生成のクロップ値修正と Node 18 互換性対応

### DIFF
--- a/scripts/store-screenshots/generate.ts
+++ b/scripts/store-screenshots/generate.ts
@@ -70,122 +70,129 @@ if (missingLocales.length > 0) {
   process.exit(1);
 }
 
-// Check that raw screenshots exist
-const missingFiles: string[] = [];
-for (const locale of locales) {
-  const dir = LOCALE_DIR_MAP[locale];
-  for (const screen of SCREEN_MAP) {
-    const rawPath = path.join(RAW_DIR, dir, screen.filename);
-    try {
-      await fs.access(rawPath);
-    } catch {
-      missingFiles.push(rawPath);
-    }
-  }
-}
-
-if (missingFiles.length > 0) {
-  console.error(
-    `\n${missingFiles.length} raw screenshot(s) missing:\n` +
-      missingFiles.map((f) => `  - ${f}`).join('\n') +
-      '\n\nRun the Maestro capture scripts first (see docs/how-to/workflow/store_screenshots.md).\n',
-  );
-  process.exit(1);
-}
-
 // ---------------------------------------------------------------------------
 // Main
 // ---------------------------------------------------------------------------
 
-const startTime = Date.now();
-let count = 0;
-let errors = 0;
-
-console.log(
-  `\nGenerating store screenshots...` +
-    `\n  Stores:  ${storeNames.join(', ')}` +
-    `\n  Locales: ${locales.length} (${locales.join(', ')})` +
-    `\n  Screens: ${SCREEN_MAP.length}` +
-    `\n  Total:   ${storeNames.length * locales.length * SCREEN_MAP.length} images\n`,
-);
-
-const browser = await chromium.launch({ headless: true });
-
-try {
+async function main() {
+  // Check that raw screenshots exist
+  const missingFiles: string[] = [];
   for (const locale of locales) {
-    const localeDir = LOCALE_DIR_MAP[locale];
-    const text = marketingTextMap[locale];
-    if (!text) {
-      console.error(`  [SKIP] No marketing text for locale: ${locale}`);
-      continue;
-    }
-
-    // Pre-build font CSS once per locale (reused across screens × stores)
-    const fontCss = buildFontCss(locale);
-    const fontStack = getFontStack(locale);
-
+    const dir = LOCALE_DIR_MAP[locale];
     for (const screen of SCREEN_MAP) {
-      const rawPath = path.join(RAW_DIR, localeDir, screen.filename);
-
-      // Crop once per screen (reused across stores)
-      let croppedBase64: string;
+      const rawPath = path.join(RAW_DIR, dir, screen.filename);
       try {
-        croppedBase64 = await cropToBase64(rawPath);
-      } catch (err) {
-        console.error(`  [ERROR] Crop failed: ${rawPath}`, err);
-        errors++;
+        await fs.access(rawPath);
+      } catch {
+        missingFiles.push(rawPath);
+      }
+    }
+  }
+
+  if (missingFiles.length > 0) {
+    console.error(
+      `\n${missingFiles.length} raw screenshot(s) missing:\n` +
+        missingFiles.map((f) => `  - ${f}`).join('\n') +
+        '\n\nRun the Maestro capture scripts first (see docs/how-to/workflow/store_screenshots.md).\n',
+    );
+    process.exit(1);
+  }
+
+  const startTime = Date.now();
+  let count = 0;
+  let errors = 0;
+
+  console.log(
+    `\nGenerating store screenshots...` +
+      `\n  Stores:  ${storeNames.join(', ')}` +
+      `\n  Locales: ${locales.length} (${locales.join(', ')})` +
+      `\n  Screens: ${SCREEN_MAP.length}` +
+      `\n  Total:   ${storeNames.length * locales.length * SCREEN_MAP.length} images\n`,
+  );
+
+  const browser = await chromium.launch({ headless: true });
+
+  try {
+    for (const locale of locales) {
+      const localeDir = LOCALE_DIR_MAP[locale];
+      const text = marketingTextMap[locale];
+      if (!text) {
+        console.error(`  [SKIP] No marketing text for locale: ${locale}`);
         continue;
       }
 
-      const marketingText = text[screen.key as ScreenKey];
+      // Pre-build font CSS once per locale (reused across screens × stores)
+      const fontCss = buildFontCss(locale);
+      const fontStack = getFontStack(locale);
 
-      for (const store of storeNames) {
-        const size = STORE_SIZES[store];
+      for (const screen of SCREEN_MAP) {
+        const rawPath = path.join(RAW_DIR, localeDir, screen.filename);
 
+        // Crop once per screen (reused across stores)
+        let croppedBase64: string;
         try {
-          // Build HTML
-          const html = buildHtml({
-            marketingText,
-            screenshotBase64: croppedBase64,
-            fontCss,
-            fontStack,
-            locale,
-          });
-
-          // Render
-          const rawPng = await renderPage(browser, html, size);
-
-          // Post-process
-          const finalPng = await flattenAndVerify(rawPng, size.width, size.height);
-
-          // Write
-          const outDir = path.join(STORE_DIR, store, localeDir);
-          await fs.mkdir(outDir, { recursive: true });
-          const outPath = path.join(outDir, screen.filename);
-          await fs.writeFile(outPath, finalPng);
-
-          count++;
+          croppedBase64 = await cropToBase64(rawPath);
         } catch (err) {
-          console.error(
-            `  [ERROR] ${store}/${localeDir}/${screen.filename}`,
-            err,
-          );
+          console.error(`  [ERROR] Crop failed: ${rawPath}`, err);
           errors++;
+          continue;
+        }
+
+        const marketingText = text[screen.key as ScreenKey];
+
+        for (const store of storeNames) {
+          const size = STORE_SIZES[store];
+
+          try {
+            // Build HTML
+            const html = buildHtml({
+              marketingText,
+              screenshotBase64: croppedBase64,
+              fontCss,
+              fontStack,
+              locale,
+            });
+
+            // Render
+            const rawPng = await renderPage(browser, html, size);
+
+            // Post-process
+            const finalPng = await flattenAndVerify(rawPng, size.width, size.height);
+
+            // Write
+            const outDir = path.join(STORE_DIR, store, localeDir);
+            await fs.mkdir(outDir, { recursive: true });
+            const outPath = path.join(outDir, screen.filename);
+            await fs.writeFile(outPath, finalPng);
+
+            count++;
+          } catch (err) {
+            console.error(
+              `  [ERROR] ${store}/${localeDir}/${screen.filename}`,
+              err,
+            );
+            errors++;
+          }
         }
       }
-    }
 
-    console.log(`  ${locale} done`);
+      console.log(`  ${locale} done`);
+    }
+  } finally {
+    await browser.close();
   }
-} finally {
-  await browser.close();
+
+  const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
+  console.log(
+    `\nComplete: ${count} images generated in ${elapsed}s` +
+      (errors > 0 ? ` (${errors} errors)` : '') +
+      `\nOutput:   ${STORE_DIR}/\n`,
+  );
+
+  if (errors > 0) process.exit(1);
 }
 
-const elapsed = ((Date.now() - startTime) / 1000).toFixed(1);
-console.log(
-  `\nComplete: ${count} images generated in ${elapsed}s` +
-    (errors > 0 ? ` (${errors} errors)` : '') +
-    `\nOutput:   ${STORE_DIR}/\n`,
-);
-
-if (errors > 0) process.exit(1);
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});

--- a/scripts/store-screenshots/lib/config.ts
+++ b/scripts/store-screenshots/lib/config.ts
@@ -1,4 +1,7 @@
 import * as path from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
 
 // ---------------------------------------------------------------------------
 // Store target sizes
@@ -21,14 +24,14 @@ export const STORE_SIZES: Record<string, StoreSize> = {
 };
 
 // ---------------------------------------------------------------------------
-// Raw screenshot crop values (Pixel 8a: 1080 x 2400)
+// Raw screenshot crop values (Maestro on Pixel 8a: 720 x 1520)
 // ---------------------------------------------------------------------------
 
 /** Pixels to remove from top (Android status bar in Demo Mode) */
-export const CROP_TOP = 100;
+export const CROP_TOP = 56;
 
 /** Pixels to remove from bottom (Android gesture bar) */
-export const CROP_BOTTOM = 60;
+export const CROP_BOTTOM = 32;
 
 // ---------------------------------------------------------------------------
 // Screen filename <-> marketing-text key mapping
@@ -73,7 +76,7 @@ export const LOCALE_DIR_MAP: Record<string, string> = {
 // Paths
 // ---------------------------------------------------------------------------
 
-const SCRIPTS_DIR = path.resolve(import.meta.dirname, '..');
+const SCRIPTS_DIR = path.resolve(__dirname, '..');
 export const PROJECT_ROOT = path.resolve(SCRIPTS_DIR, '../..');
 export const RAW_DIR = path.join(PROJECT_ROOT, 'screenshots/raw');
 export const STORE_DIR = path.join(PROJECT_ROOT, 'screenshots/store');


### PR DESCRIPTION
## Summary

- Maestro 実寸 (720x1520) に合わせてクロップ値を修正 (100/60 → 56/32)
- top-level await を async main() でラップし tsx/esbuild CJS モードに対応
- `import.meta.dirname` を `fileURLToPath` に置換し Node 18 互換に

## Test plan
- [x] `pnpm store-screenshots --store apple --lang ja` — 4枚正常生成 (3.1s)
- [x] `pnpm store-screenshots --store google --lang ja,de` — 8枚正常生成、ドイツ語 shrink-to-fit 動作確認
- [x] `pnpm store-screenshots --store all` — 全152枚を68.7sで生成、エラーゼロ
- [x] 全152枚の寸法(1320x2868/1080x1920)・チャンネル数(3)・アルファなし検証パス
- [x] CJK (ja/zh-Hans/zh-Hant/ko)、タイ語、ヒンディー語のフォント描画目視確認済み

:robot: Generated with [Claude Code](https://claude.com/claude-code)