### PR TITLE
docs: store_screenshots.md に Phase 2（自動合成）の手順を追加

### DIFF
--- a/docs/how-to/workflow/store_screenshots.md
+++ b/docs/how-to/workflow/store_screenshots.md
@@ -1,9 +1,9 @@
-# Google Play ストアスクリーンショット生成手順
+# ストアスクリーンショット生成手順（Apple App Store / Google Play）
 
-> ステータス: 運用中（Phase 1 完了、Phase 2 進行中）
+> ステータス: 運用中（Phase 1 + Phase 2 完了）
 > 初版: 2026-03-30 / 最終更新: 2026-03-31
 
-19言語 × 4画面 = 76枚のストア提出用スクリーンショットを生成する手順です。
+19言語 × 4画面 × 2ストア = 152枚のストア提出用スクリーンショットを生成する手順です。
 アプリUIが変わったとき・言語を追加したときに再実行してください。
 
 想定:
@@ -11,6 +11,7 @@
 - Expo SDK 54 Dev Build（SCREENSHOT_MODE=1）
 - Maestro CLI インストール済み
 - Node.js 22.x（Metro bundler 用）
+- Playwright + Sharp インストール済み（Phase 2 用）
 
 ---
 
@@ -19,24 +20,30 @@
 ### ワークフローの全体像
 
 ```
-Phase 1: 撮影 (自動)          Phase 2: 仕上げ (Figma + 手動)
-┌──────────────────────┐     ┌───────────────────────────────┐
-│ Maestro + ADB        │     │ Figma MCP: テキスト設定        │
-│ → raw スクショ 76枚   │────►│ 手動: フレーム変更・スクショ挿入 │
-│   (screenshots/raw/) │     │ 手動: エクスポート → 提出画像    │
-└──────────────────────┘     └───────────────────────────────┘
+Phase 1: 撮影 (自動)               Phase 2: 合成 (自動)
+┌───────────────────────┐         ┌────────────────────────────────────┐
+│ Maestro + ADB          │         │ Playwright + Sharp                  │
+│ → raw スクショ 76枚     │────────►│ → Apple 用 76枚 (1320×2868)         │
+│   (screenshots/raw/)   │         │ → Google Play 用 76枚 (1080×1920)   │
+└───────────────────────┘         │   (screenshots/store/)              │
+                                  └────────────────────────────────────┘
+                                    ↑ コマンド1つ、約1分で完了
 ```
 
-### Google Play 仕様
+### ストア仕様比較
 
-| 項目 | 要件 |
-|---|---|
-| サイズ | **1080 × 1920 px**（縦）推奨 |
-| アスペクト比 | 9:16。**最大辺が最小辺の2倍を超えると却下** |
-| フォーマット | JPEG or 24bit PNG（**透過NG**） |
-| ファイルサイズ | 最大 8MB/枚 |
-| 枚数 | 1言語あたり最小2枚 / 最大8枚 |
-| Feature Graphic | 1024 × 500 px（**公開に必須** → 別途対応） |
+| 項目 | Apple App Store | Google Play |
+|---|---|---|
+| サイズ | **1320 × 2868 px**（iPhone 6.9"） | **1080 × 1920 px**（9:16） |
+| フォーマット | PNG or JPEG（**透過NG**） | 24bit PNG or JPEG（**透過NG**） |
+| 色空間 | sRGB or Display P3 | sRGB（24bit） |
+| ファイルサイズ | 制限なし（実質） | 最大 8MB/枚 |
+| 枚数 | 1〜10枚/デバイスサイズ/言語 | 2〜8枚/言語 |
+| 必須デバイス | iPhone 6.9"（他サイズは自動縮小） | Phone のみ |
+| iPad | Repolog は iPhone のみ → **不要** | — |
+| Feature Graphic | なし | 1024 × 500 px（**公開に必須** → 別途対応） |
+
+> **ポイント:** Apple は 6.9" の画像さえあれば、6.7" / 6.5" / 6.1" / 5.5" は自動縮小される。
 
 ### 撮影する4画面
 
@@ -84,6 +91,13 @@ inject-locale.mjs <locale>
 scripts/store-screenshots/
 ├── data/
 │   └── marketing-text.ts          # 19言語×4枚分のキャッチコピー（TypeScript）
+├── lib/                           # Phase 2: 合成スクリプト群
+│   ├── config.ts                  # ストアサイズ・ロケール・パス定数
+│   ├── template.ts                # HTMLテンプレート生成（白背景+テキスト+角丸スクショ）
+│   ├── fonts.ts                   # ロケール別Noto Sans @font-face生成
+│   ├── renderer.ts                # Playwright ヘッドレスChrome描画
+│   └── postprocess.ts             # Sharpクロップ・アルファ除去・sRGB埋込
+├── generate.ts                    # Phase 2 CLIエントリポイント
 ├── backups/ja/                    # 日本語バックアップデータ（写真含む）
 ├── inject-locale.mjs              # 言語別データ注入スクリプト（19言語分のデータ内蔵）
 ├── capture.sh                     # 単一言語の撮影スクリプト
@@ -100,7 +114,10 @@ docs/store-listing/android/screenshots/
 └── sample-data.ts                 # 19言語サンプルレポートデータ（参照用）
 
 screenshots/                       # .gitignore済み
-└── raw/{lang}/                    # Maestro撮影の生スクショ（Figmaに挿入する素材）
+├── raw/{lang}/                    # Phase 1: Maestro撮影の生スクショ（720×1520）
+└── store/                         # Phase 2: ストア提出用の完成画像
+    ├── apple/{lang}/              #   Apple App Store (1320×2868)
+    └── google/{lang}/             #   Google Play (1080×1920)
 ```
 
 ---
@@ -109,13 +126,14 @@ screenshots/                       # .gitignore済み
 
 ```
 [Step 1] 準備（初回のみ / APK未ビルド時のみ）
-    ↓ .env設定 → Dev APK ビルド → インストール
+    ↓ .env設定 → Dev APK ビルド → インストール → Playwright + Sharp インストール
 [Step 2] Metro起動 + ADB接続確認
     ↓ Metro bundler起動 → ポートフォワーディング
-[Step 3] 撮影（19言語一括 or 1言語ずつ）
+[Step 3] 撮影（Phase 1: 19言語一括 or 1言語ずつ）
     ↓ データ注入 → Demo Mode → Maestro → raw PNG 76枚
-[Step 4] Figmaで仕上げ（手動）
-    ↓ フレーム調整 → スクショ挿入 → エクスポート → 提出画像 76枚
+[Step 4] 合成（Phase 2: 自動）
+    ↓ pnpm store-screenshots → Apple 76枚 + Google Play 76枚 = 152枚
+[Step 5] 後片付け
 ```
 
 ---
@@ -161,6 +179,23 @@ env -u ADB_SERVER_SOCKET adb install dist/repolog-dev-screenshot.apk
 
 > **`env -u ADB_SERVER_SOCKET`** はWSL2環境でADBが正しく動作するために必要。
 > ADB_SERVER_SOCKET環境変数をunset（無効化）してからadbを実行する。
+
+### 1-4. Phase 2 の依存パッケージ（初回のみ）
+
+```bash
+# devDependencies のインストール（playwright, sharp, tsx）
+pnpm install
+
+# Playwright 用 Chromium ダウンロード（約100MB）
+npx playwright install chromium
+```
+
+| コマンド | 意味 |
+|---|---|
+| `pnpm install` | package.json の全依存パッケージをインストール |
+| `npx playwright install chromium` | Playwright が使う Chromium ブラウザバイナリをダウンロード。`~/.cache/ms-playwright/` に保存される |
+
+> これは Phase 2（ストア画像合成）で必要。Phase 1（撮影）だけなら不要。
 
 ---
 
@@ -286,43 +321,136 @@ Windows エクスプローラーからも確認可能:
 
 ---
 
-## Step 4: Figma で仕上げ（手動）
+## Step 4: ストア画像の自動合成（Phase 2）
 
-Figma ファイル: https://www.figma.com/design/CTrun6PxYslD5z1JvntweR/
+Phase 1 で撮影した raw スクリーンショットから、ストア提出用の完成画像を自動生成する。
 
-19言語分のページとマーケティングテキストは Figma MCP で設定済み。
+### 4-0. Phase 2 の仕組み
 
-### 4-1. テンプレート修正（初回のみ）
+```
+screenshots/raw/{lang}/0X_*.png  (720×1520, Android)
+    ↓ Sharp: 上56px/下32pxクロップ（ステータスバー・ジェスチャーバー除去）
+    ↓ base64 data URI に変換
+    ↓ HTML テンプレートに埋め込み（白背景 + マーケティングテキスト + 角丸スクショ）
+    ↓ Playwright: ヘッドレスChrome で HTML を描画 → PNG キャプチャ
+    ↓ Sharp: アルファチャンネル除去 + sRGB ICC 埋め込み + 寸法検証
+    ↓
+screenshots/store/apple/{lang}/0X_*.png   (1320×2868, 24bit RGB, sRGB)
+screenshots/store/google/{lang}/0X_*.png  (1080×1920, 24bit RGB, sRGB)
+```
 
-1つのページで以下を修正し、他のページにコピーする:
+合成後の画像レイアウト:
+- **背景**: 白 (#FFFFFF)
+- **マーケティングテキスト**: 上部に配置、Bold、ダーク (#1A1A1A)、長い言語は自動縮小
+- **スクリーンショット**: 中央〜下部、角丸、ドロップシャドウ付き
+- **デバイスフレーム（ベゼル）**: なし
 
-| 修正項目 | 現状 | 修正後 |
-|---|---|---|
-| フレームサイズ | 1284 × 2778 px | **1080 × 1920 px** |
-| デバイスフレーム | iPhone 16 Pro | **Android (Pixel)** |
-| 背景色 | 白 | お好みで設定 |
+### 4-1. 初回セットアップ（Phase 2 依存パッケージ）
 
-> **重要:** 1284×2778 のままエクスポートすると Google Play に却下されます（アスペクト比 2.16:1 > 許容上限 2:1）。
+```bash
+# devDependencies に playwright, sharp, tsx を追加済み
+pnpm install
 
-### 4-2. スクリーンショットを挿入
+# Playwright 用の Chromium ブラウザをダウンロード（約100MB、初回のみ）
+npx playwright install chromium
+```
 
-各ページの4フレームに、`screenshots/raw/{lang}/` の画像をドラッグ:
-
-| フレーム | 挿入する画像 |
+| コマンド | 意味 |
 |---|---|
-| 1枚目 | `01_home.png` |
-| 2枚目 | `02_editor_top.png` |
-| 3枚目 | `03_editor_bottom.png` |
-| 4枚目 | `04_pdf_preview.png` |
+| `pnpm install` | package.json の依存パッケージをインストール |
+| `npx playwright install chromium` | Playwright が使うヘッドレス Chrome をダウンロード |
 
-19言語 × 4枚 = 76回の挿入が必要。
+### 4-2. 全19言語 × 両ストアを一括生成
 
-### 4-3. エクスポート
+```bash
+pnpm store-screenshots
+```
 
-各ページの4スライスを PNG で書き出す:
-- フォーマット: **PNG**（24bit、透過なし）
-- サイズ: **1080 × 1920 px**
-- ファイルサイズ: 8MB以下
+このコマンドが内部で行うこと（1枚あたり）:
+1. raw スクショを Sharp で読み込み、Android UI（ステータスバー56px + ジェスチャーバー32px）をクロップ
+2. クロップした画像を base64 エンコードして HTML テンプレートに埋め込み
+3. `marketing-text.ts` からその言語のキャッチコピーを取得
+4. `assets/fonts/` の Noto Sans Variable TTF をロケールに応じて `@font-face` で読み込み
+5. Playwright でヘッドレス Chrome を起動し、HTML をターゲットサイズで描画
+6. PNG スクリーンショットを取得
+7. Sharp でアルファチャンネルを除去（白に統合）、sRGB ICC プロファイルを埋め込み
+8. 出力寸法を検証（1ピクセルでもズレたらエラー）
+9. `screenshots/store/{apple|google}/{lang}/` に保存
+
+所要時間: 約1分（152枚）
+
+### 4-3. 特定の言語・ストアだけ生成（テスト・やり直し用）
+
+```bash
+# Apple のみ、日本語のみ（約3秒）
+pnpm store-screenshots -- --store apple --lang ja
+
+# Google Play のみ、日本語と英語
+pnpm store-screenshots -- --store google --lang ja,en
+
+# Apple のみ、全19言語
+pnpm store-screenshots -- --store apple
+```
+
+| フラグ | 意味 | デフォルト |
+|---|---|---|
+| `--store` | `apple`, `google`, `all` のいずれか | `all`（両方） |
+| `--lang` | カンマ区切りのロケール（例: `ja,en,de`） | 全19言語 |
+
+> **注意:** pnpm 経由でフラグを渡す場合、`--` の後にフラグを書く。
+
+### 4-4. 出力の確認
+
+```bash
+# Apple 用
+ls screenshots/store/apple/ja_日本語/
+# → 01_home.png  02_editor_top.png  03_editor_bottom.png  04_pdf_preview.png
+
+# Google Play 用
+ls screenshots/store/google/ja_日本語/
+# → 01_home.png  02_editor_top.png  03_editor_bottom.png  04_pdf_preview.png
+```
+
+Windows エクスプローラーからも確認可能:
+- Apple: `\\wsl.localhost\Ubuntu\home\doooo\04_app-factory\apps\Repolog\screenshots\store\apple\`
+- Google: `\\wsl.localhost\Ubuntu\home\doooo\04_app-factory\apps\Repolog\screenshots\store\google\`
+
+### 4-5. 寸法・品質の一括検証（任意）
+
+```bash
+node -e "
+const sharp = require('sharp');
+const fs = require('fs');
+const path = require('path');
+async function main() {
+  const storeDir = 'screenshots/store';
+  let pass = 0, fail = 0;
+  for (const store of ['apple', 'google']) {
+    const ew = store === 'apple' ? 1320 : 1080;
+    const eh = store === 'apple' ? 2868 : 1920;
+    const dirs = fs.readdirSync(path.join(storeDir, store));
+    for (const dir of dirs) {
+      const files = fs.readdirSync(path.join(storeDir, store, dir)).filter(f => f.endsWith('.png'));
+      for (const file of files) {
+        const m = await sharp(path.join(storeDir, store, dir, file)).metadata();
+        if (m.width !== ew || m.height !== eh || m.hasAlpha || m.channels !== 3) {
+          console.log('FAIL:', store, dir, file);
+          fail++;
+        } else { pass++; }
+      }
+    }
+  }
+  console.log(pass + ' PASS, ' + fail + ' FAIL');
+}
+main();
+"
+```
+
+| チェック項目 | Apple 期待値 | Google 期待値 |
+|---|---|---|
+| 幅 × 高さ | 1320 × 2868 | 1080 × 1920 |
+| チャンネル数 | 3 (RGB) | 3 (RGB) |
+| アルファ | なし | なし |
 
 ---
 
@@ -353,6 +481,8 @@ Metro を起動しているターミナルで `Ctrl+C` を押す。
 
 ## トラブルシューティング
 
+### Phase 1（撮影）
+
 | 症状 | 原因 | 対策 |
 |---|---|---|
 | `adb: device not found` | ADB接続切れ | USBケーブル再接続 → `env -u ADB_SERVER_SOCKET adb devices` で確認 |
@@ -360,17 +490,33 @@ Metro を起動しているターミナルで `Ctrl+C` を押す。
 | Home画面の写真がグレー | DB の `local_uri` がフルパスでない | `inject-locale.mjs` が `file:///data/user/0/...` のフルパスで設定するので、スクリプト経由で再注入 |
 | Metro が `toReversed is not a function` | Node 18 を使っている | Node 22 で起動する: `export PATH="$HOME/.nvm/versions/node/v22.21.0/bin:$PATH"` |
 | `INSTALL_FAILED_UPDATE_INCOMPATIBLE` | 既存APKと署名が異なる | 先に `adb uninstall com.dooooraku.repolog` してから install |
-| Figma エクスポートが Google Play で却下 | フレームサイズが 1284×2778 のまま | **1080×1920** にリサイズしてからエクスポート |
 | テキストに□（文字化け） | `\u2009`（thin space）をNoto Sansが描画不可 | 通常スペースに置換済み |
 | PDFプレビューが写真ページを表示 | Maestro フローにスクロール指示があった | スクロールを削除し表紙ビューのまま撮影 |
-| Figma で `getNodeById` が null | ページ切替前にノードアクセスした | `await figma.setCurrentPageAsync(page)` を先に実行 |
+
+### Phase 2（合成）
+
+| 症状 | 原因 | 対策 |
+|---|---|---|
+| `raw screenshot(s) missing` | Phase 1 の撮影が未実行 | 先に Step 3 を実行して `screenshots/raw/` を生成する |
+| `Chromium ... not found` | Playwright の Chromium が未ダウンロード | `npx playwright install chromium` を実行 |
+| CJK テキストが □（豆腐） | フォントファイルが見つからない | `assets/fonts/` に Noto Sans Variable TTF が存在するか確認 |
+| `Dimension mismatch` エラー | Playwright の描画サイズが期待値と不一致 | `lib/config.ts` の `APPLE_SIZE` / `GOOGLE_SIZE` を確認 |
+| 出力 PNG が Apple に却下される | アルファチャンネルが残っている | `lib/postprocess.ts` の `.flatten()` が正しく動作しているか確認。Sharp のバージョンを確認 |
+| テキストが切れる / 小さすぎる | shrink-to-fit の最小値以下 | `lib/template.ts` の shrink-to-fit 下限値（2.5vw）を調整、またはテキストを短くする |
+| Android ステータスバーが見える | クロップ値が不足 | `lib/config.ts` の `CROP_TOP`（現在56px）を増やす |
 
 ---
 
 ## 参考リンク
 
-- [Google Play スクショ仕様](https://support.google.com/googleplay/android-developer/answer/9866151)
-- [Google Play ベストプラクティス](https://support.google.com/googleplay/android-developer/answer/13393723)
+### Phase 1（撮影）
 - [Maestro ドキュメント](https://docs.maestro.dev)
 - [ADB Demo Mode](https://android.googlesource.com/platform/frameworks/base/+/master/packages/SystemUI/docs/demo_mode.md)
-- [Figma デザインファイル](https://www.figma.com/design/CTrun6PxYslD5z1JvntweR/)
+- [Google Play スクショ仕様](https://support.google.com/googleplay/android-developer/answer/9866151)
+
+### Phase 2（合成）
+- [Apple スクリーンショット仕様](https://developer.apple.com/help/app-store-connect/reference/screenshot-specifications/)
+- [Google Play スクショ仕様](https://support.google.com/googleplay/android-developer/answer/9866151)
+- [Playwright ドキュメント](https://playwright.dev/docs/screenshots)
+- [Sharp ドキュメント](https://sharp.pixelplumbing.com/)
+- [Noto Sans フォント](https://fonts.google.com/noto)


### PR DESCRIPTION
## Summary

- `store_screenshots.md` を Phase 2 自動化に対応するよう更新
- タイトルを Apple App Store / Google Play 両対応に変更
- Step 4 を Figma 手動版から Playwright + Sharp 自動版に完全書き換え
- Apple / Google Play 仕様比較表、Phase 2 トラブルシューティング、参考リンクを追加

## Test plan
- [x] ドキュメント内容が実際のスクリプト動作と一致することを確認済み

:robot: Generated with [Claude Code](https://claude.com/claude-code)