### PR TITLE
docs: add IAP build verification and EAS env var lessons

### DIFF
--- a/.github/workflows/build-ios-testflight.yml
+++ b/.github/workflows/build-ios-testflight.yml
@@ -44,6 +44,9 @@ jobs:
           REVENUECAT_IOS_API_KEY=${{ secrets.REVENUECAT_IOS_API_KEY }}
           DOTENV
 
+      - name: Verify required secrets are set
+        run: node scripts/prebuild-env-check.mjs ios
+
       - name: Verify code quality
         run: pnpm verify
 

--- a/docs/how-to/development/android_build.md
+++ b/docs/how-to/development/android_build.md
@@ -57,6 +57,24 @@ echo "$ANDROID_HOME"
 
 ---
 
+## 1.5 プレビルド環境変数チェック（必須）
+
+本番/プレビュービルドの前に、必要な API キーが設定されていることを確認します。
+
+```bash
+# ローカル .env の確認
+node scripts/prebuild-env-check.mjs android
+```
+
+このチェックは `pnpm build:android:aab:local` 等のビルドコマンドに組み込み済みです。
+失敗した場合はビルドが開始されません。
+
+> **重要**: EAS local build（`eas build --local`）は `.env` を一時ビルドディレクトリにコピーしません。
+> API キーは **EAS サーバーの環境変数** から注入されます。
+> 新しいキーを追加した場合は `eas env:create --environment production --name KEY_NAME --value VALUE --visibility sensitive` で登録してください。
+>
+> 現在の EAS 環境変数を確認: `npx eas-cli env:list --environment production`
+
 ## 2. 品質チェック（CIと同じ順番）
 
 ```bash

--- a/docs/how-to/workflow/whole_workflow.md
+++ b/docs/how-to/workflow/whole_workflow.md
@@ -317,11 +317,14 @@ gh api repos/doooooraku/Repolog/milestones/<旧番号> --method PATCH -f state='
 * **作業内容**：
   * `docs/how-to/workflow/release_notes_template.md` に沿ってリリースノートを作成
   * `vX.Y.Z-rc.N` または `vX.Y.Z` のタグを作成し、`gh release create` で公開
+  * EAS環境変数の確認: `npx eas-cli env:list --environment production` で全APIキーが登録されているか確認
   * `docs/how-to/development/android_build.md`の実施
   * `docs/how-to/development/ios_build.md`の実施
+  * ビルド後検証: `assets/app.config` の `extra` フィールドでAPIキー埋め込みを確認
+  * IAP検証: RevenueCat Dashboard で全商品の Store Status が active であることを確認
 * **INPUT**：main、リリースノート、Storeメタ情報
 * **OUTPUT**：GitHub Release / TestFlight / Play内部テスト / 本番リリース
-* **完了条件**：ストアの審査/配信が通る。
+* **完了条件**：ストアの審査/配信が通る。Paywall画面で金額が表示され、購入ボタンが動作する。
 * **担当**：人間
 
 ---

--- a/docs/reference/lessons.md
+++ b/docs/reference/lessons.md
@@ -167,13 +167,15 @@
 
 ### 2026-04-06: RevenueCat APIキーがビルドに含まれず課金画面が全プラン「Unavailable」
 - **状況**: クローズドテスト用 .aab をビルドしてGoogle Playにアップロードしたが、Paywall画面の全プランが「Unavailable」でボタンも反応しない。iOS・Android両方で発生
-- **根本原因**: .aab ビルド時に `.env` に `REVENUECAT_ANDROID_API_KEY` / `REVENUECAT_IOS_API_KEY` が未設定（空文字）だった。ビルド後にキーを追加したが、既にアップロード済みのバイナリには反映されない
+- **根本原因**: EAS local build（`eas build --local`）は `.gitignore` に従い `.env` を一時ビルドディレクトリにコピーしない。環境変数は EAS サーバーの environment 設定から注入されるが、RevenueCat の API キーが EAS production 環境に未登録だった。結果、`app.config.ts` の `process.env.REVENUECAT_ANDROID_API_KEY` が undefined → `?? ''` で空文字にフォールバック → バイナリに空文字が埋め込まれた
+- **なぜ ADMOB は動いたか**: ADMOB のキーは EAS production 環境変数に登録済みだったため正常に注入された
 - **診断方法**: APK の `assets/app.config` を抽出して `extra` フィールドを確認 → 空文字を確認。logcat で RevenueCat/BillingClient のログがゼロ → SDK未初期化を確認
 - **ルール**:
-  1. ビルドスクリプトに環境変数チェックを必ず入れる（`scripts/prebuild-env-check.mjs`）
-  2. `.env` を変更したら必ずリビルドする（設定変更はバイナリに自動反映されない）
-  3. ビルド後は `assets/app.config` の `extra` フィールドでAPIキーの埋め込みを検証する
-  4. RevenueCat SDKのログが出ない場合は、APIキーの不在を最初に疑う
+  1. 新しい API キーを追加したら **3 箇所を同時更新**: `.env`（ローカル開発）、EAS 環境変数（`eas env:create --environment production`）、`.env.example`（チーム共有）
+  2. ビルドスクリプトに環境変数チェックを必ず入れる（`scripts/prebuild-env-check.mjs`）
+  3. ビルド後は `assets/app.config` の `extra` フィールドで API キーの埋め込みを検証する
+  4. RevenueCat SDK のログが出ない場合は、API キーの不在を最初に疑う
+  5. EAS ビルドログの「Environment variables loaded from ... environment on EAS」行で、必要な変数がリストされているか確認する
 
 ---
 


### PR DESCRIPTION
## Summary
- lessons.md: document EAS local build .env behavior and 3-place API key update rule
- android_build.md: add Section 1.5 prebuild env check with EAS env var instructions
- whole_workflow.md: add IAP verification steps to W-12 release process
- build-ios-testflight.yml: add prebuild-env-check.mjs to CI pipeline

Follow-up to #278 (IAP fix)

Generated with [Claude Code](https://claude.com/claude-code)