### PR TITLE
fix(ci): postbuild-verify.mjs のIPA対応 — TestFlightパイプライン修正

### DIFF
--- a/docs/reference/lessons.md
+++ b/docs/reference/lessons.md
@@ -194,6 +194,19 @@
 
 ---
 
+## CI/CD
+
+### 2026-04-06: postbuild-verify.mjs がiOS IPA未対応でTestFlightパイプライン失敗
+- **状況**: GitHub Actions の `Build iOS & Submit to TestFlight` ワークフロー初回実行時、IPAビルドは成功するがpostbuild-verify.mjsのステップで `assets/app.config not found` エラーが発生。TestFlightへの提出がブロックされた
+- **根本原因**: postbuild-verify.mjs はAndroid APK/AAB用に設計され、`assets/app.config` と `base/assets/app.config` のみ検索していた。IPA内ではパスが `Payload/AppName.app/assets/app.config` であり不一致。加えて `REQUIRED_KEYS` にAndroid専用キーが含まれておりiOS検証時に不適切だった
+- **対策（実施済み）**: (1) パスマッチを `endsWith('assets/app.config')` に変更しIPA対応 (2) ファイル拡張子でプラットフォーム判別し必須キーを切り替え (3) JSDoc・エラーメッセージをAPK/AAB/IPA対応に更新
+- **ルール**:
+  1. ビルド検証スクリプトを新プラットフォームのCIワークフローで使う前に、スクリプトのJSDocとコード内パスパターンを確認する
+  2. プラットフォーム固有のCIステップは、対象プラットフォームのアーカイブ形式（APK/AAB/IPA）で事前にローカルテストする
+  3. 必須チェックキーはプラットフォーム別に分離する（iOSビルドにAndroid APIキーは不要）
+
+---
+
 ### Claude Code トリガーフレーズ
 - 有効なフレーズ: 「デバッグセッションを分析して」「rebuild して」「Maestro スクショ付きで E2E テストして」
 - 分析時は summary.md → app_logcat.log → screenshots/ の順に読むのが効率的

--- a/scripts/postbuild-verify.mjs
+++ b/scripts/postbuild-verify.mjs
@@ -2,21 +2,29 @@
 /**
  * Post-build verification script.
  *
- * Extracts assets/app.config from an APK or AAB and verifies that
+ * Extracts assets/app.config from an APK, AAB, or IPA and verifies that
  * required API keys are embedded (not empty).  Exits with code 1 if
  * any required key is missing so CI / build scripts can catch it.
  *
  * Usage:
- *   node scripts/postbuild-verify.mjs <path-to-apk-or-aab>
+ *   node scripts/postbuild-verify.mjs <path-to-apk-aab-or-ipa>
  *   node scripts/postbuild-verify.mjs dist/repolog-production.aab
  *   node scripts/postbuild-verify.mjs dist/repolog-preview-local.apk
+ *   node scripts/postbuild-verify.mjs Repolog.ipa
  */
 import { readFileSync } from 'node:fs';
 import { inflateRawSync } from 'node:zlib';
-import { resolve } from 'node:path';
+import { resolve, extname } from 'node:path';
 
-const REQUIRED_KEYS = [
+// ---------------------------------------------------------------------------
+// Platform-specific required keys
+// ---------------------------------------------------------------------------
+const REQUIRED_KEYS_ANDROID = [
   'REVENUECAT_ANDROID_API_KEY',
+  'REVENUECAT_IOS_API_KEY',
+];
+
+const REQUIRED_KEYS_IOS = [
   'REVENUECAT_IOS_API_KEY',
 ];
 
@@ -32,11 +40,14 @@ const INFO_KEYS = [
 
 const archivePath = process.argv[2];
 if (!archivePath) {
-  console.error('Usage: node scripts/postbuild-verify.mjs <path-to-apk-or-aab>');
+  console.error('Usage: node scripts/postbuild-verify.mjs <path-to-apk-aab-or-ipa>');
   process.exit(1);
 }
 
 const absPath = resolve(process.cwd(), archivePath);
+const ext = extname(absPath).toLowerCase();
+const isIOS = ext === '.ipa';
+const REQUIRED_KEYS = isIOS ? REQUIRED_KEYS_IOS : REQUIRED_KEYS_ANDROID;
 
 let buf;
 try {
@@ -47,7 +58,7 @@ try {
 }
 
 // ---------------------------------------------------------------------------
-// Extract assets/app.config from the ZIP (APK and AAB are both ZIP format)
+// Extract assets/app.config from the ZIP (APK, AAB, and IPA are all ZIP format)
 // ---------------------------------------------------------------------------
 function extractAppConfig(buffer) {
   let offset = 0;
@@ -65,7 +76,9 @@ function extractAppConfig(buffer) {
       const extraLen = buffer.readUInt16LE(offset + 28);
       const name = buffer.toString('utf8', offset + 30, offset + 30 + nameLen);
 
-      if (name === 'assets/app.config' || name === 'base/assets/app.config') {
+      // Android: assets/app.config or base/assets/app.config
+      // iOS IPA: Payload/AppName.app/assets/app.config
+      if (name.endsWith('assets/app.config')) {
         const dataStart = offset + 30 + nameLen + extraLen;
         const compData = buffer.slice(dataStart, dataStart + compSize);
 
@@ -88,7 +101,7 @@ function extractAppConfig(buffer) {
 const raw = extractAppConfig(buf);
 if (!raw) {
   console.error('\x1b[31m✗ assets/app.config not found in the archive.\x1b[0m');
-  console.error('  This file should be present in any Expo-built APK or AAB.');
+  console.error('  This file should be present in any Expo-built APK, AAB, or IPA.');
   process.exit(1);
 }
 
@@ -105,7 +118,8 @@ const extra = config.extra ?? {};
 // ---------------------------------------------------------------------------
 // Report
 // ---------------------------------------------------------------------------
-console.log(`\n  Post-build verification: ${archivePath}\n`);
+const platform = isIOS ? 'iOS' : 'Android';
+console.log(`\n  Post-build verification (${platform}): ${archivePath}\n`);
 
 const missing = [];
 


### PR DESCRIPTION
## Summary
- `postbuild-verify.mjs` がAndroid APK/AAB専用設計だったため、iOS TestFlightワークフローの「Verify API keys embedded in IPA」ステップで `assets/app.config not found` エラーが発生
- IPA内パス構造 (`Payload/AppName.app/assets/app.config`) に対応するため、パスマッチを `endsWith('assets/app.config')` に変更
- ファイル拡張子でプラットフォーム判別し、必須キーをiOS/Android別に切り替え

## Changes
- **`scripts/postbuild-verify.mjs`**: IPA対応 + プラットフォーム別必須キー
- **`docs/reference/lessons.md`**: 教訓記録

## Test plan
- [x] Android AAB (`dist/repolog-production.aab`) でpostbuild-verifyが通ることを確認（リグレッションなし）
- [x] `pnpm verify` 5ゲート全クリア（lint 0エラー / 124テスト合格 / i18n / config）
- [ ] GitHub Actions で `Build iOS & Submit to TestFlight` ワークフローを再実行して成功確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)