### PR TITLE
feat(build): SHA-stamp Android AAB and add forbidden bundle string canary

### DIFF
--- a/docs/how-to/workflow/google_play_release.md
+++ b/docs/how-to/workflow/google_play_release.md
@@ -186,17 +186,21 @@ pnpm build:android:aab:local
 このコマンドの中身（`package.json` で定義済み）：
 
 ```bash
-npx eas-cli@latest build -p android --profile production --local --output dist/repolog-production.aab
+node scripts/prebuild-env-check.mjs android \
+  && npx eas-cli@latest build -p android --profile production --local --output dist/repolog-production.aab \
+  && node scripts/postbuild-verify.mjs dist/repolog-production.aab --stamp-sha
 ```
 
 | オプション | 意味 |
 |-----------|------|
+| `prebuild-env-check.mjs android` | EAS 環境変数（REVENUECAT_*, ADMOB_*）が production に登録済か事前検証 |
 | `npx eas-cli@latest` | EAS CLIの最新版を一時的にダウンロードして実行 |
 | `build` | 「ビルドして」という命令 |
 | `-p android` | Androidプラットフォームを指定 |
 | `--profile production` | `eas.json` の `production` 設定を使用（AAB形式、autoIncrement有効） |
 | `--local` | クラウドではなくローカルでビルド（**無料枠を消費しない**） |
-| `--output dist/repolog-production.aab` | 完成ファイルの出力先を指定 |
+| `--output dist/repolog-production.aab` | 完成ファイルの一時出力先（直後に SHA スタンプ付きにリネームされる） |
+| `postbuild-verify.mjs ... --stamp-sha` | (1) API キー埋込検証 (2) 禁止文字列 canary 検証 (3) `dist/repolog-production-{shortSha}.aab` にリネーム |
 
 #### 初回ビルド時の特別な対話
 
@@ -217,19 +221,33 @@ npx eas-cli@latest build -p android --profile production --local --output dist/r
 
 | 項目 | 値 |
 |------|-----|
-| 出力ファイル | `dist/repolog-production.aab` |
+| 出力ファイル | `dist/repolog-production-{shortSha}.aab`（例: `dist/repolog-production-c71bb11.aab`）|
 | ファイルサイズ | 約123MB |
 | 所要時間（初回） | 約30-45分 |
 | 所要時間（2回目以降） | 約6-15分 |
 | versionCode | 自動インクリメント（`eas.json` の `autoIncrement: true`） |
 
+> **2026-04-09 以降**: `pnpm build:android:aab:local` は `dist/repolog-production.aab` でビルドした後、`scripts/postbuild-verify.mjs --stamp-sha` がファイル名を `dist/repolog-production-{shortSha}.aab` に自動リネームします（`shortSha` は `git rev-parse --short HEAD` の出力）。これによりファイル名から「どのコミットからビルドされた成果物か」が視認できます。詳細は `docs/reference/lessons.md` の「2026-04-09: 「修正したのに反映されていない」報告の真因はビルド配信ギャップ」参照。
+
 #### ビルド完了の確認
 
 ```bash
-ls -lh dist/repolog-production.aab
+ls -lh dist/repolog-production-*.aab
 ```
 
-`dist/repolog-production.aab` が存在し、サイズが100MB以上あれば成功。
+最新のスタンプ済み AAB が存在し、サイズが100MB以上あれば成功。アップロード対象は **必ずファイル名のコミット SHA を `git log --oneline -1` の出力と一致するかチェック** してから Play Console に上げること。
+
+#### ビルド成果物の検証ステップ（postbuild-verify.mjs）
+
+`pnpm build:android:aab:local` の最後で自動実行される `scripts/postbuild-verify.mjs` は以下を確認します。すべて ✓ でなければ Play Console にアップロードしないでください:
+
+| チェック | 失敗時の意味 |
+|---------|------------|
+| API キー埋込（REVENUECAT_*, ADMOB_*）| EAS 環境変数が production に登録されていない |
+| Forbidden bundle string canary（`pdfGeneratingProgress` 等の削除済みマーカー）| ビルドキャッシュが古い／JS bundle が stale |
+| `--stamp-sha` リネーム | git repo 外で実行されたなど（警告のみで継続） |
+
+Forbidden string list はスクリプト内 `FORBIDDEN_BUNDLE_STRINGS` 配列で管理。新しい削除済み文字列は PR ごとにここへ追記してください。
 
 ### 1-7. Keystoreバックアップ（初回ビルド後に必ず実施）
 
@@ -292,17 +310,23 @@ keytool -list -v -keystore ./path/to/keystore.jks
 
 ### 2-1. AABファイルをWindowsに転送
 
-WSL2からWindowsのダウンロードフォルダにコピー：
+WSL2からWindowsのダウンロードフォルダにコピー（**必ず最新の SHA スタンプ付きファイル**を選ぶこと）:
 
 ```bash
-cp dist/repolog-production.aab /mnt/c/Users/doooo/Downloads/
+# 1) 最新ビルドの commit SHA を確認
+git log --oneline -1
+
+# 2) その SHA を含む AAB をコピー（例: c71bb11）
+cp dist/repolog-production-$(git rev-parse --short HEAD).aab /mnt/c/Users/doooo/Downloads/
 ```
 
 | 部分 | 意味 |
 |------|------|
 | `cp` | ファイルをコピーするコマンド |
-| `dist/repolog-production.aab` | コピー元（WSL2内のビルド成果物） |
+| `dist/repolog-production-$(git rev-parse --short HEAD).aab` | コピー元（現在の HEAD でビルドした AAB）|
 | `/mnt/c/Users/doooo/Downloads/` | コピー先（WindowsのダウンロードフォルダをWSL2からアクセスするパス） |
+
+> **配信ミス防止**: コピー前に `ls -lh dist/repolog-production-*.aab` を実行して `dist/` 内に古い世代の AAB が残っていないか確認。残っていてアップロード対象が紛らわしい場合は古いものを削除してから操作する。
 
 ### 2-2. Google Play Console でアップロード
 
@@ -311,7 +335,7 @@ cp dist/repolog-production.aab /mnt/c/Users/doooo/Downloads/
 3. 左メニュー →「テスト」→「内部テスト」
 4. **「新しいリリースを作成」** をクリック
 5. 「App Bundle」セクションの **「アップロード」** をクリック
-6. Windowsのダウンロードフォルダから `repolog-production.aab` を選択
+6. Windowsのダウンロードフォルダから `repolog-production-{shortSha}.aab` を選択（**ファイル名の SHA が `git log --oneline -1` の SHA と一致するか必ず目視確認**）
 7. アップロード完了を待つ（123MB、数分かかる）
 
 ### 2-3. リリースの詳細を入力
@@ -510,8 +534,8 @@ grep secrets .gitignore
 ### 4-6. EAS Submit を実行（2回目以降）
 
 ```bash
-# ローカルのAABファイルを直接提出
-npx eas-cli@latest submit -p android --path ./dist/repolog-production.aab
+# ローカルのAABファイルを直接提出（現在の HEAD でビルドしたものを選ぶ）
+npx eas-cli@latest submit -p android --path "./dist/repolog-production-$(git rev-parse --short HEAD).aab"
 
 # またはEASビルド済みの最新を提出
 npx eas-cli@latest submit -p android --latest
@@ -521,7 +545,7 @@ npx eas-cli@latest submit -p android --latest
 |-----------|------|
 | `submit` | 「ストアに提出して」という命令 |
 | `-p android` | Androidを対象 |
-| `--path ./dist/...` | ローカルのAABファイルを直接指定 |
+| `--path ./dist/...` | ローカルのAABファイルを直接指定（SHA スタンプ付き）|
 | `--latest` | EASサーバー上の最新ビルドを自動選択 |
 
 ### 4-7. ビルドから提出までの一括フロー（推奨）
@@ -530,11 +554,11 @@ npx eas-cli@latest submit -p android --latest
 # Step 1: 品質チェック
 pnpm verify
 
-# Step 2: ローカルビルド
+# Step 2: ローカルビルド（dist/repolog-production-{sha}.aab に出力される）
 pnpm build:android:aab:local
 
-# Step 3: 自動提出
-npx eas-cli@latest submit -p android --path ./dist/repolog-production.aab
+# Step 3: 自動提出（同じ HEAD の SHA を解決して渡す）
+npx eas-cli@latest submit -p android --path "./dist/repolog-production-$(git rev-parse --short HEAD).aab"
 ```
 
 ---
@@ -544,15 +568,15 @@ npx eas-cli@latest submit -p android --path ./dist/repolog-production.aab
 ### 5-1. アップデートの流れ
 
 ```bash
-# 1. コード修正
+# 1. コード修正 & マージ
 # 2. 品質チェック
 pnpm verify
 
-# 3. AABビルド（versionCodeは自動インクリメント）
+# 3. AABビルド（versionCodeは自動インクリメント、ファイル名に commit SHA が付く）
 pnpm build:android:aab:local
 
 # 4. 提出（EAS Submit設定済みの場合）
-npx eas-cli@latest submit -p android --path ./dist/repolog-production.aab
+npx eas-cli@latest submit -p android --path "./dist/repolog-production-$(git rev-parse --short HEAD).aab"
 ```
 
 ### 5-2. バージョン管理

--- a/docs/reference/lessons.md
+++ b/docs/reference/lessons.md
@@ -130,6 +130,47 @@
   3. **ADR の前提が時間で崩れるのは自然なこと**: ADR-0002 (2026-01) の「フォント埋め込みで固定」という決定は当時正しかったが、SDK 54 + Android Chromium の挙動変化で前提が崩れた。ADR は Supersede 可能な生きたドキュメントとして扱う
   4. **リスク分離原則**: 1 行のコード修正と 10+ ファイルの dead code 削除を同一 PR に混ぜない。失敗時の切り分けが困難になる。本 PR では修正のみ、削除は Phase 2b に分離
 
+### 2026-04-08 (Phase 3a 完了): PDF hang の真因は OS-level WebView renderer pool の累積 (Issue #298)
+
+- **状況**: PR #299 (attempt 1 cap 10s) は Issue #298 の暫定緩和だったが、根本原因は未解明のまま生存。Phase 3a として実機 (SHARP SH-M25 / Android 14) で `dumpsys meminfo` + `ps -A` + `dumpsys gfxinfo` を **8 cell マトリクス** で観測した
+- **観測ハーネス**: `scripts/phase3a_observe.sh` を新規開発 (init/cell/status/summary/regen/dry-run の 6 サブコマンド)。trigger 検知 → T+0/+5/+9/+12 で自動 dump → end marker 検知で完了 → cell_summary.json 生成。観測 SOP は `docs/how-to/development/pdf_observation_protocol.md` にまとめた
+- **決定的観測 (C1 vs C7)**: 完全に同じ条件 (force-stop + Fixture + standard A4 + 10 photos) で **C1 = success / C7 = HANG** という結果差を取得。差の内訳:
+  - **Repolog プロセスの Native Heap 差: 128 KB のみ** (29.32 MB vs 29.30 MB) — H5 (アプリ内メモリ圧迫) の **強い反証**
+  - **OS-level WebView 関連プロセスの RSS 差: +233 MB** (~319 MB → ~552 MB) — プロセス数 5 → 7 に膨張
+  - 膨張源は 1 つ前の C6 (新規未保存レポート 10 枚 export) 時点で発生し、`am force-stop com.dooooraku.repolog` でも **kill されずに C7 に持ち越された**
+- **真因モデル (確定)**: PDF 出力時に `react-native-webview` (preview 用) と `expo-print` (Print engine 用) がそれぞれ `com.google.android.webview` の `sandboxed_process0` を要求 → 通常は再利用されるが、新規未保存レポート 10 枚のような高負荷シナリオで **新規 spawn される子プロセスが残留**。Repolog は別 UID なので `kill` も `force-stop` もできない (`adb shell kill -9` ですら `Operation not permitted`)。Android の LRU eviction を待つしか無い
+- **transient な性質**: 観測中 idle 状態で WebView pool が **7 → 4 に自動減少** することを確認。永続累積ではなく rapid consecutive exports が hang trigger
+- **ルール**:
+  1. **アプリのプロセス境界の外を観測しないと真因を見落とす**。`dumpsys meminfo com.dooooraku.repolog` だけを見ていた限り「Repolog の Native Heap は変わっていない」までしか分からず、本当の汚染源 (`com.google.android.webview` プロセス群) を見落とす。今後の hang/leak 系問題は **`adb shell ps -A | grep webview` と `dumpsys meminfo` を併用** すること
+  2. **`am force-stop <my package>` は WebView 子プロセスを kill しない**。webview_zygote とその子は別 UID で、自分のアプリの force-stop では触れない。「force-stop で全部リセットされる」という暗黙の前提は誤り
+  3. **`Image.clearMemoryCache()` / `router.dismissAll()` はアプリプロセス内のみ有効**。OS レベルの WebView renderer pool には届かない。ADR-0013 の防御層は「Repolog の navigation/expo-image cache をクリア」までで、その境界の外には及ばない事実を ADR-0013 補遺に追記すべき
+  4. **「同じ条件で異なる結果」を見たら process 境界を疑う**。アプリ内 state が同じでも OS-level の他プロセス state が違えば結果が変わる。再現性が壊れたら「観測の解像度が足りない」という選択肢を常に第一候補に
+  5. **観測前に決定木を書く**。Phase 3a では「Native Heap が +30MB → H5 支持 / WebView count が +N → H6 支持」を事前に書いておいたため、結果が出た瞬間に解釈ができた。事後解釈だと確証バイアスがかかる
+  6. **観測ツールは資産として残す**。`scripts/phase3a_observe.sh` は本 Issue の調査だけでなく次の hang 系調査でも再利用可能。1 回限りの ad-hoc スクリプトにせず、汎用性を持たせて `docs/how-to/development/pdf_observation_protocol.md` に SOP として残した
+  7. **観測の自動化が背後で起きている "ユーザーの意図しない挙動" を全部記録できる**。Phase 3a の最初の C1 (汚染版) で logcat kill のバグでユーザーの意図せぬ追加 export が 4 回分記録されてしまったが、その「事故データ」が結果的に **新規未保存レポートの hang パターン** を示す決定的な evidence になった。事故は時に最良のデータを生む — **生データは捨てない**
+- **次フェーズ**: ADR-0016 (本 lesson と同日付) に真因を文書化。Phase 3d (緩和策の比較検討) は当初予定だったが、下記「Final Decision」により **キャンセル**
+
+#### Final Decision (2026-04-08): **受容 (Accepted as Limitation)**
+
+ユーザー (@doooooraku) と合議の上、**アプリ側で追加の緩和策は実施しない**ことを正式に決定。PR #299 の attempt 1 cap (10s) を **永続的な対応** として維持する。Issue #298 はクローズ。
+
+**受容の根拠 (canonical rationale)**:
+
+> 「**真因は Android system レベル (`com.google.android.webview` プロセス群の状態管理) にあり、その介入はアプリ側の責任範囲を超えている**」 — @doooooraku
+
+**この判断の正当性**:
+
+1. **責任範囲の認識**: アプリの責任は「アプリ自身のコードと設定」までであり、Android system 内部の renderer LRU 管理に介入することは責任範囲外。境界を越えた領域での対症療法は **「自分の家で他人の家の壊れ方を補修しようとする」** ことに等しく、長期的に保守不能になる
+2. **既存の止血が機能している**: PR #299 で 44s → 12s。ユーザーは PDF を依然として受け取れる (Pro 会員の画質が時々下がる制約は残るが、機能停止ではない)
+3. **追加緩和の ROI が低い**: cool-down (Option A) や警告通知 (Option B) はユーザー体感を別の形で悪化させるだけで真因解決にはならない
+4. **将来の再評価を排除しない**: ADR-0016 に Re-evaluation criteria を明記。ストアレビューや Pro 解約理由の変化を月次でモニタリングし、閾値を超えたら ADR-0017 を起こして再判断する
+
+**追加されたメタ教訓**:
+
+8. **「真因が分かったら受容も valid な選択肢」**。原因究明の目的は必ずしも修正のためではない。原因が「アプリの責任範囲外」と判明したら、**修正しないという判断もまた engineering judgment**。受容を恥じる必要はなく、むしろ責任範囲を明確化することはコード負債の蓄積を防ぐ
+9. **「受容」と「諦め」を区別する**。受容は (a) 真因が観測データで特定済み (b) 再評価条件が明文化済み (c) 観測ハーネスが資産として残っている という前提があってこそ valid。これらが揃わなければただの「諦め」になる
+10. **「Issue を閉じる勇気」**。open バックログにある Issue は無意識のストレス源。「真因は分かった、対策は意図的に実施しない」と決めたら **クローズすることが正解**。半年後の自分が「これ何だっけ?」と再調査ループに入らないように、ADR と lessons.md に決定の根拠を残しておく
+
 ### 2026-04-08: ADR-0009 が修正したはずの iOS 空白ページが SSoT ドリフトで再発（ADR-0017）
 
 - **状況**: ユーザー報告「iOS で出力した PDF の写真ページ直後に空白ページが入る」。提供された 6 ファイル（iOS 18.6.2）を PyMuPDF で構造解析した結果、5 件は標準的な「1 photo / 期待 2 ページ → 実体 3 ページ」、1 件は「**70 photos / 期待 71 ページ → 実体 141 ページ**」（large レイアウトで全ての写真ページに空白ページペアが付く壊滅的状況）。各空白ページの実体は `</div>...</div>` の中に `N/M` フッターテキストだけが y=4pt（ページ最上部）に描画されており、ADR-0009 が修正したはずの「iOS WebKit subpixel フッター押し出し」現象が完全に再発していた
@@ -479,6 +520,34 @@
   2. Pressable の `disabled={state}` プロパティも同じ理由で state flush 待ちの race window を持つため、state 単独では不十分
   3. try-catch-finally で ref の解放を保証する。早期 return でも finally は走るので安全
   4. 将来この pattern を捨てようとしたら `__tests__/pdfExportGuard.test.ts` が落ちる設計にしてある
+
+---
+
+## リリース配信パイプライン
+
+### 2026-04-09: 「修正したのに反映されていない」報告の真因はビルド配信ギャップ
+- **状況**: ユーザー報告「iOS PDF にまだ空白ページがある / Android にまだプログレスバーが出る」。コミット `c71bb11` (#300/#301) と `7ced68e` (#298/#299) は前日中に main にマージ済み、iOS TestFlight への workflow_dispatch ビルドも `headSha=c71bb11` で success、ローカル `dist/repolog-production.aab` も c71bb11 マージ後 23 分にビルドされており、bundle 内 grep で `pdfGeneratingProgress` 0 件 / `photo-no` 存在 / `page-footer` 2件を確認 — つまり**最新コードは各ビルド成果物に確実に入っていた**
+- **真因**: コードの問題ではなく、**ローカル `dist/repolog-production.aab` が Play Console にアップロードされておらず、ユーザー端末では PR #299 マージ前 (= 14:45 JST 以前) に作られた古い AAB が動き続けていた**。スクリーンショットに「PDFを作成中... 0%」プログレスバーが映っていたことが、PR #299 の i18n キー削除前のビルドである動かぬ証拠
+- **構造的な根本原因**:
+  1. main へのマージとストア配布が完全に分離した別ステップで、後者は人手 (`pnpm build:android:aab:local` → 手動 Play Console アップロード)
+  2. iOS workflow `build-ios-testflight.yml` は `workflow_dispatch` または `push tag:v*` のみ起動。連続マージ中はタグを切らずにマージしてしまい、どのビルドがどの commit の修正を含むのかが不可視に
+  3. `dist/repolog-production.aab` は固定パスで上書きされ続け、ファイル名から「いつ・どの commit でビルドしたか」が一切読めない
+  4. Play Console にアップロード済みの AAB が最新コードを含むかを機械的に確認する手段がなかった
+- **対策（実施済み）**: PR feat/build-artifact-sha-stamping にて
+  1. `scripts/postbuild-verify.mjs` に **forbidden bundle string check** を追加。`FORBIDDEN_BUNDLE_STRINGS` 配列に「最新ビルドには絶対に存在してはいけない文字列」(`pdfGeneratingProgress` など) を列挙し、bundle に検出されたら exit 1 で aupload を阻止
+  2. `--stamp-sha` フラグを追加。`pnpm build:android:aab:local` 実行後に `dist/repolog-production.aab` が `dist/repolog-production-{shortSha}.aab` に自動リネームされるため、ファイル名から「どの commit からビルドされたか」が一目で分かる
+  3. `package.json` の `build:android:aab:local` を `--stamp-sha` 付きに更新。preview-local APK は `install:device` が固定パスを参照するため stamp 対象外
+- **ルール**:
+  1. **「修正済み」と「ユーザー端末に届いた」の間には常に配信レイヤがある**。バグ報告を受けたら、まず `(a) ソースに修正が入っているか` `(b) ビルド成果物に修正が入っているか` `(c) ストアにアップロードされているか` `(d) ユーザー端末にインストールされているか` の 4 点を順番に検証する
+  2. **ビルド成果物のファイル名にコミット SHA を埋める**。固定パスで上書きされる成果物は、何世代前のものか分からなくなった瞬間に事故源になる
+  3. **削除された i18n キーは forbidden canary に登録する**。ユーザー報告のスクリーンショットに削除済みの文字列が映っていたら、それは古いビルドが動いている動かぬ証拠 — 同種の証拠を機械的に取れるようにスクリプト化する
+  4. **「コードはマージ済み = ユーザーに届いた」と思い込まない**。Solo dev 環境では特に、配信ステップが手動になりやすい。マージ後の TODO 「タグ → CI → TestFlight 送信完了 → Play Console アップロード」をチェックリスト化して docs/how-to/workflow/google_play_release.md と ios_testflight_release.md に置く
+  5. **「ユーザーの古いキャッシュかもしれない」と決めつける前に bundle 文字列で証拠を取る**。`unzip -p dist/repolog-production.aab base/assets/index.android.bundle | grep -c <expected-removed-string>` を 30 秒で叩けるようにしておく
+- **再発防止のセルフチェック**: 次回「直したのに直っていない」と聞いたら、以下を順に確認:
+  1. `git log --oneline | head -5` で直近のコミットを確認
+  2. `unzip -p dist/repolog-production.aab base/assets/index.android.bundle | grep -c <forbidden-string>` で bundle が最新か検証
+  3. `gh run list --workflow=build-ios-testflight.yml --limit 5 --json headSha,createdAt` で TestFlight ビルドの SHA を確認
+  4. ファイル名に SHA が入っていれば視認で完結。入っていなければまず `--stamp-sha` で stamp し直す
 
 ---
 

--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
     "build:android": "expo prebuild --platform android && cd android && ./gradlew bundleRelease",
     "build:android:apk:local": "node scripts/prebuild-env-check.mjs android && npx eas-cli@latest build -p android --profile preview-local-apk --local --output dist/repolog-preview-local.apk && node scripts/postbuild-verify.mjs dist/repolog-preview-local.apk",
     "build:android:apk:cloud": "node scripts/prebuild-env-check.mjs android && npx eas-cli@latest build -p android --profile preview-cloud-apk",
-    "build:android:aab:local": "node scripts/prebuild-env-check.mjs android && npx eas-cli@latest build -p android --profile production --local --output dist/repolog-production.aab && node scripts/postbuild-verify.mjs dist/repolog-production.aab",
+    "build:android:aab:local": "node scripts/prebuild-env-check.mjs android && npx eas-cli@latest build -p android --profile production --local --output dist/repolog-production.aab && node scripts/postbuild-verify.mjs dist/repolog-production.aab --stamp-sha",
     "build:android:aab:cloud": "node scripts/prebuild-env-check.mjs android && npx eas-cli@latest build -p android --profile production",
     "install:device": "adb install -r \"$(wslpath -w dist/repolog-preview-local.apk)\"",
     "store-screenshots": "npx tsx scripts/store-screenshots/generate.ts"

--- a/scripts/postbuild-verify.mjs
+++ b/scripts/postbuild-verify.mjs
@@ -2,22 +2,32 @@
 /**
  * Post-build verification script.
  *
- * Extracts assets/app.config from an APK, AAB, or IPA and verifies that
- * required API keys are embedded (not empty).  Exits with code 1 if
- * any required key is missing so CI / build scripts can catch it.
+ * For APK / AAB / IPA build artifacts, this script:
+ *   1. Verifies required API keys are embedded in assets/app.config (not empty).
+ *   2. Greps the JS bundle for forbidden marker strings that should NOT exist
+ *      in the latest build (canary against shipping stale code).
+ *   3. (Android only, with --stamp-sha) renames the artifact to include the
+ *      current short git SHA so the build artifact is traceable to a commit.
+ *
+ * Exits with code 1 if any check fails so CI / build scripts can catch it.
  *
  * Usage:
- *   node scripts/postbuild-verify.mjs <path-to-apk-aab-or-ipa>
- *   node scripts/postbuild-verify.mjs dist/repolog-production.aab
+ *   node scripts/postbuild-verify.mjs <path-to-apk-aab-or-ipa> [--stamp-sha]
+ *   node scripts/postbuild-verify.mjs dist/repolog-production.aab --stamp-sha
  *   node scripts/postbuild-verify.mjs dist/repolog-preview-local.apk
  *   node scripts/postbuild-verify.mjs Repolog.ipa
+ *
+ * Forbidden-string canary list: see FORBIDDEN_BUNDLE_STRINGS below.
+ * Add a new entry whenever a PR removes a user-visible string that must
+ * never re-appear in shipped builds.
  */
-import { readFileSync } from 'node:fs';
+import { readFileSync, renameSync, existsSync } from 'node:fs';
 import { inflateRawSync } from 'node:zlib';
-import { resolve, extname } from 'node:path';
+import { resolve, extname, dirname, basename, join } from 'node:path';
+import { execSync } from 'node:child_process';
 
 // ---------------------------------------------------------------------------
-// Platform-specific required keys
+// Platform-specific required keys (embedded in assets/app.config)
 // ---------------------------------------------------------------------------
 const REQUIRED_KEYS_ANDROID = [
   'REVENUECAT_ANDROID_API_KEY',
@@ -37,16 +47,42 @@ const INFO_KEYS = [
 ];
 
 // ---------------------------------------------------------------------------
+// Forbidden bundle strings — canary against shipping stale builds.
+//
+// Each entry is a string that MUST NOT appear inside the JS bundle of a
+// freshly built artifact.  These are typically i18n keys, component names,
+// or constants that were removed in a recent PR.  If the string is found,
+// the artifact contains an old build of the JS bundle (Metro / EAS cache
+// issue, prebuild skip, or wrong source tree) and must NOT be uploaded.
+//
+// To add an entry: write the string + the PR/commit that removed it.
+// To remove an entry: only after confirming the string is no longer
+// referenced anywhere in the codebase.
+// ---------------------------------------------------------------------------
+const FORBIDDEN_BUNDLE_STRINGS = [
+  // Removed in PR #299 (commit 7ced68e, 2026-04-08): progress bar UI was
+  // deleted from app/reports/[id]/pdf.tsx and the i18n key was removed from
+  // all 19 locales.  If this key shows up again, the build is stale or
+  // someone re-introduced the progress bar without updating this list.
+  'pdfGeneratingProgress',
+];
 
-const archivePath = process.argv[2];
+// ---------------------------------------------------------------------------
+// CLI argument parsing
+// ---------------------------------------------------------------------------
+const args = process.argv.slice(2);
+const stampSha = args.includes('--stamp-sha');
+const archivePath = args.find((a) => !a.startsWith('--'));
+
 if (!archivePath) {
-  console.error('Usage: node scripts/postbuild-verify.mjs <path-to-apk-aab-or-ipa>');
+  console.error('Usage: node scripts/postbuild-verify.mjs <path-to-apk-aab-or-ipa> [--stamp-sha]');
   process.exit(1);
 }
 
 const absPath = resolve(process.cwd(), archivePath);
 const ext = extname(absPath).toLowerCase();
 const isIOS = ext === '.ipa';
+const isAndroid = ext === '.aab' || ext === '.apk';
 const REQUIRED_KEYS = isIOS ? REQUIRED_KEYS_IOS : REQUIRED_KEYS_ANDROID;
 
 let buf;
@@ -58,9 +94,17 @@ try {
 }
 
 // ---------------------------------------------------------------------------
-// Extract assets/app.config from the ZIP (APK, AAB, and IPA are all ZIP format)
+// ZIP scanner — finds the first Local File Header whose name matches the
+// predicate and returns its decompressed contents.
+//
+// NOTE: this scanner only handles standard Local File Header storage
+// (general purpose bit flag bit 3 = 0).  It does NOT handle Data Descriptor
+// format (compSize=0 in LFH, sizes appear after compressed data).  Android
+// APK/AAB use the standard format, so this is fine for them.  iOS IPA uses
+// Data Descriptor for some entries — see lessons.md 2026-04-07 for why this
+// script is no longer wired into the iOS pipeline.
 // ---------------------------------------------------------------------------
-function extractAppConfig(buffer) {
+function extractEntry(buffer, predicate) {
   let offset = 0;
   while (offset < buffer.length - 4) {
     // Local file header signature = 0x04034b50 (little-endian: 50 4B 03 04)
@@ -76,14 +120,12 @@ function extractAppConfig(buffer) {
       const extraLen = buffer.readUInt16LE(offset + 28);
       const name = buffer.toString('utf8', offset + 30, offset + 30 + nameLen);
 
-      // Android: assets/app.config or base/assets/app.config
-      // iOS IPA: Payload/AppName.app/assets/app.config
-      if (name.endsWith('assets/app.config')) {
+      if (predicate(name)) {
         const dataStart = offset + 30 + nameLen + extraLen;
         const compData = buffer.slice(dataStart, dataStart + compSize);
 
-        if (compressionMethod === 0) return compData.toString('utf8');
-        if (compressionMethod === 8) return inflateRawSync(compData).toString('utf8');
+        if (compressionMethod === 0) return compData;
+        if (compressionMethod === 8) return inflateRawSync(compData);
 
         throw new Error(`Unsupported compression method: ${compressionMethod}`);
       }
@@ -94,6 +136,19 @@ function extractAppConfig(buffer) {
     }
   }
   return null;
+}
+
+function extractAppConfig(buffer) {
+  // Android: assets/app.config or base/assets/app.config
+  // iOS IPA: Payload/AppName.app/assets/app.config (subject to Data Descriptor caveat)
+  const entry = extractEntry(buffer, (name) => name.endsWith('assets/app.config'));
+  return entry ? entry.toString('utf8') : null;
+}
+
+function extractJsBundle(buffer) {
+  // Android Hermes bundle: base/assets/index.android.bundle
+  const entry = extractEntry(buffer, (name) => name.endsWith('index.android.bundle'));
+  return entry ? entry.toString('utf8') : null;
 }
 
 // ---------------------------------------------------------------------------
@@ -155,3 +210,90 @@ if (missing.length > 0) {
 }
 
 console.log('\x1b[32m✓ Post-build check passed: all required keys are embedded.\x1b[0m\n');
+
+// ---------------------------------------------------------------------------
+// Forbidden bundle string check (Android only — see Data Descriptor caveat)
+// ---------------------------------------------------------------------------
+if (isAndroid && FORBIDDEN_BUNDLE_STRINGS.length > 0) {
+  const bundle = extractJsBundle(buf);
+  if (!bundle) {
+    console.error(
+      '\x1b[31m✗ Could not extract index.android.bundle from the artifact.\x1b[0m',
+    );
+    console.error('  Forbidden-string canary check skipped — please investigate.\n');
+    process.exit(1);
+  }
+
+  const hits = [];
+  for (const needle of FORBIDDEN_BUNDLE_STRINGS) {
+    if (bundle.includes(needle)) hits.push(needle);
+  }
+
+  if (hits.length > 0) {
+    console.error(
+      `\x1b[31m✗ Forbidden bundle string(s) found — this build is STALE.\x1b[0m`,
+    );
+    for (const h of hits) console.error(`    • ${h}`);
+    console.error('');
+    console.error('  These strings should have been removed by recent PRs.');
+    console.error('  The artifact contains an old JS bundle and must NOT be uploaded.');
+    console.error('  Fix: clean the build cache and re-run the build.');
+    console.error('        rm -rf node_modules/.cache android/.gradle ios/build');
+    console.error('        pnpm build:android:aab:local\n');
+    process.exit(1);
+  }
+
+  console.log(
+    `\x1b[32m✓ Forbidden-string canary passed: 0 of ${FORBIDDEN_BUNDLE_STRINGS.length} forbidden marker(s) found in bundle.\x1b[0m\n`,
+  );
+}
+
+// ---------------------------------------------------------------------------
+// SHA stamping — rename the artifact to include the current short git SHA
+// so a human can visually verify which commit a given file was built from.
+// Only runs when --stamp-sha is passed and only for Android artifacts.
+// ---------------------------------------------------------------------------
+if (stampSha && isAndroid) {
+  // Resolve the SHA from the project repo (process.cwd()), NOT from the
+  // artifact's directory — the artifact may live anywhere (dist/, /tmp/, …).
+  let shortSha;
+  try {
+    shortSha = execSync('git rev-parse --short HEAD', {
+      cwd: process.cwd(),
+      encoding: 'utf8',
+    }).trim();
+  } catch {
+    console.error(
+      '\x1b[33m⚠ --stamp-sha requested but git rev-parse failed; skipping rename.\x1b[0m\n',
+    );
+    process.exit(0);
+  }
+
+  const dir = dirname(absPath);
+  const base = basename(absPath, ext);
+
+  // If the file already has a SHA suffix that matches HEAD, do nothing.
+  if (base.endsWith(`-${shortSha}`)) {
+    console.log(`  Already stamped with current SHA: ${basename(absPath)}\n`);
+    process.exit(0);
+  }
+
+  // Strip any pre-existing -<sha> suffix (7 lowercase hex chars) so we don't
+  // end up with double suffixes when re-running.
+  const cleanBase = base.replace(/-[0-9a-f]{7}$/i, '');
+  const stampedName = `${cleanBase}-${shortSha}${ext}`;
+  const stampedPath = join(dir, stampedName);
+
+  if (existsSync(stampedPath) && stampedPath !== absPath) {
+    console.log(
+      `\x1b[33m⚠ ${stampedName} already exists; overwriting with the new build.\x1b[0m`,
+    );
+  }
+
+  renameSync(absPath, stampedPath);
+  console.log(`\x1b[32m✓ Stamped with commit SHA:\x1b[0m`);
+  console.log(`    ${basename(absPath)} → ${stampedName}`);
+  console.log('');
+  console.log('  Upload this file to Play Console:');
+  console.log(`    ${stampedPath}\n`);
+}


### PR DESCRIPTION
## 背景

ユーザーから「iOS PDF にまだ空白ページがある / Android にまだプログレスバーが出る」という報告を受け、6 名チーム分析を実施。結果、**コードはすべて main にマージ済み**だが、**ユーザー端末に古いビルドが配信されたまま**という配信レイヤの問題と判明しました。

決定的な証拠：
- `dist/repolog-production.aab` (mtime 2026-04-08 22:47 JST) を `unzip -p ... base/assets/index.android.bundle` で抽出して `pdfGeneratingProgress` (PR #299 で削除した i18n キー) を grep → **0 件**。つまり最新コードは入っていた
- ユーザー提供スクショ 14900.jpg には「PDFを作成中... 0%」プログレスバーが映っており、これは PR #299 (commit 7ced68e, 2026-04-08 14:45 JST) で削除した UI → ユーザー端末は **PR #299 マージ前の古いビルド** で動いていた

つまり今回の事象は「コードは正しい / ビルドにも入っている / でもユーザーまで届いていない」という配信ギャップ。本 PR は**二度と同じ混乱を起こさない**ための恒久策です（今すぐ困っている問題はこの PR とは独立に「`dist/repolog-production.aab` を Play Console に再アップロード」で解決します）。

## 変更内容

### 1. `scripts/postbuild-verify.mjs` — Forbidden bundle string canary

\`\`\`js
const FORBIDDEN_BUNDLE_STRINGS = [
  // Removed in PR #299 (commit 7ced68e, 2026-04-08): progress bar UI was
  // deleted from app/reports/[id]/pdf.tsx and the i18n key was removed from
  // all 19 locales. If this key shows up again, the build is stale.
  'pdfGeneratingProgress',
];
\`\`\`

ビルド後に \`base/assets/index.android.bundle\` を抽出して上記の禁止文字列が **1 つでも見つかったら exit 1** で aupload を阻止します。新しい削除済み文字列は PR ごとにこの配列へ追記する運用。

### 2. `scripts/postbuild-verify.mjs` — \`--stamp-sha\` フラグ

ビルド成功後に \`dist/repolog-production.aab\` を \`dist/repolog-production-{shortSha}.aab\` にリネーム。これにより：
- ファイル名から「どの commit からビルドされた成果物か」が一目で分かる
- 将来 \`dist/\` に複数世代の AAB が並んでも、Play Console アップロード時に間違える確率が激減

副次効果として、リネームは **idempotent** (再実行しても no-op) で、git が無い場合は警告のみで継続。

### 3. `package.json`

\`build:android:aab:local\` のみ \`--stamp-sha\` 付きに変更。\`build:android:apk:local\` は \`install:device\` が固定パスを参照するため意図的にスタンプ対象外。

### 4. `docs/how-to/workflow/google_play_release.md`

Phase 1-6 / 2-1 / 2-2 / 4-6 / 4-7 / 5-1 を新ファイル名規約に追従。アップロード前に \`git log --oneline -1\` の SHA とファイル名の SHA を目視突合する手順を明記。

### 5. `docs/reference/lessons.md`

「リリース配信パイプライン」セクションを新規追加。\`source merged → bundle has it → store has it → device has it\` の 4 段階診断チェーンと、30 秒で叩ける self-check コマンドを記載。

> **Note**: 本 PR の lessons.md 差分には、前日の Phase 3a 観測 (ADR-0016, OS-level WebView pool 累積) で書かれて未コミットだった lessons も含まれています。これらは別トピックですが、この branch を切る前から working tree に存在しており、別 PR で切り出すと機械的な複雑さが増えるため同梱しました。

## ローカル検証結果

| チェック | 結果 |
|---|---|
| `pnpm lint` | 0 errors（17 pre-existing warnings, 私の変更とは無関係） |
| `pnpm type-check` | passes |
| `pnpm test` | 256 tests / 20 suites passing |
| `pnpm i18n:check` | 219 used, 0 unused, 0 missing |
| `pnpm config:check` | passes |
| `postbuild-verify.mjs dist/repolog-production.aab` | ✓ all required keys / forbidden-string canary 0/1 |
| `postbuild-verify.mjs <copy> --stamp-sha` | ✓ rename `repolog-production.aab` → `repolog-production-c71bb11.aab` |
| 同上を 2 回目実行 | ✓ idempotent, "Already stamped with current SHA" |

## Test plan

- [x] 既存 `dist/repolog-production.aab` で no-stamp 検証 → exit 0
- [x] 一時ディレクトリにコピーして `--stamp-sha` 実行 → ファイル名が `repolog-production-c71bb11.aab` になることを確認
- [x] スタンプ済みファイルに対して再度 `--stamp-sha` → no-op で exit 0
- [x] `pnpm verify` 全パス
- [ ] 次回の `pnpm build:android:aab:local` 実行時に `dist/repolog-production-{sha}.aab` が生成され、その SHA が `git rev-parse --short HEAD` と一致することを確認

## 関連

- 元の問題: ユーザー報告「iOS PDF 空白ページ + Android プログレスバー」(本日 2026-04-09)
- アプローチA (即時対応): 既存 `dist/repolog-production.aab` を Play Console に再アップロード + iOS は TestFlight 最新 (workflow run 24138214871, headSha c71bb11) への端末更新
- 関連ADR: ADR-0017 (PDF photo-no flow regression), ADR-0016 (PDF hang OS WebView pool accumulation)
- 関連 PR: #295, #297, #299, #301

🤖 Generated with [Claude Code](https://claude.com/claude-code)