### PR TITLE
fix(ci): use api_key_path JSON for fastlane deliver download_metadata

### DIFF
--- a/.github/workflows/download-app-store-metadata.yml
+++ b/.github/workflows/download-app-store-metadata.yml
@@ -54,19 +54,37 @@ jobs:
             exit 1
           fi
 
-      - name: Download metadata via fastlane deliver
+      - name: Create API key JSON for fastlane deliver
         env:
-          APP_STORE_CONNECT_API_KEY_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
-          APP_STORE_CONNECT_API_KEY_ISSUER_ID: ${{ secrets.ASC_API_KEY_ISSUER_ID }}
-          APP_STORE_CONNECT_API_KEY_KEY_FILEPATH: ${{ github.workspace }}/fastlane/AuthKey.p8
+          ASC_API_KEY_ID: ${{ secrets.ASC_API_KEY_ID }}
+          ASC_API_KEY_ISSUER_ID: ${{ secrets.ASC_API_KEY_ISSUER_ID }}
+        run: |
+          # fastlane deliver download_metadata は ENV 経由の API Key を読まない (known issue)。
+          # JSON ファイルとして渡す必要がある。
+          KEY_CONTENT=$(cat fastlane/AuthKey.p8)
+          cat > fastlane/api_key.json <<APIKEY
+          {
+            "key_id": "${ASC_API_KEY_ID}",
+            "issuer_id": "${ASC_API_KEY_ISSUER_ID}",
+            "key": $(echo "$KEY_CONTENT" | jq -Rs .),
+            "duration": 1200,
+            "in_house": false
+          }
+          APIKEY
+          echo "API key JSON created (key_id: ${ASC_API_KEY_ID:0:4}...)"
+
+      - name: Download metadata via fastlane deliver
         run: |
           bundle exec fastlane deliver download_metadata \
             --app_identifier com.dooooraku.repolog \
+            --api_key_path fastlane/api_key.json \
             --force
 
-      - name: Cleanup decoded API key
+      - name: Cleanup secrets
         if: always()
-        run: rm -f fastlane/AuthKey.p8
+        run: |
+          rm -f fastlane/AuthKey.p8
+          rm -f fastlane/api_key.json
 
       - name: Show downloaded files
         run: |


### PR DESCRIPTION
## Summary

Fix the "No value found for 'username'" error in the download workflow.

`fastlane deliver download_metadata` CLI does not auto-read `APP_STORE_CONNECT_API_KEY_*` env vars (unlike `upload_to_app_store`). It needs `--api_key_path` with a JSON file.

### Fix

- New step: "Create API key JSON" — generates `fastlane/api_key.json` from decoded `.p8` + Secret env vars
- Updated step: "Download metadata" — passes `--api_key_path fastlane/api_key.json`
- Cleanup: deletes both `.p8` and `.json`

### Test plan

- [ ] CI checks pass
- [ ] Merge → re-run `gh workflow run "Download App Store Metadata"` → metadata downloads successfully

🤖 Generated with [Claude Code](https://claude.com/claude-code)