### PR TITLE
fix(ci): remove sync_screenshots beta flag from push_screenshots lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -81,7 +81,6 @@ platform :ios do
       submit_for_review:                    false,
       automatic_release:                    false,
       overwrite_screenshots:                true,         # 既存スクショを上書き
-      sync_screenshots:                     true,         # ローカルに無いスクショは ASC からも消す
     )
   end
 end


### PR DESCRIPTION
fastlane 2.232 requires FASTLANE_ENABLE_BETA_DELIVER_SYNC_SCREENSHOTS for sync_screenshots: true. Remove it; overwrite_screenshots: true is sufficient.

🤖 Generated with [Claude Code](https://claude.com/claude-code)