### PR TITLE
fix(ci): disable precheck in push_screenshots lane

### DIFF
--- a/fastlane/Fastfile
+++ b/fastlane/Fastfile
@@ -81,6 +81,8 @@ platform :ios do
       submit_for_review:                    false,
       automatic_release:                    false,
       overwrite_screenshots:                true,         # 既存スクショを上書き
+      run_precheck_before_submit:           false,        # スクショ専用レーン — precheck 不要
+      precheck_include_in_app_purchases:    false,        # API Key では IAP precheck 不可
     )
   end
 end


### PR DESCRIPTION
Precheck fails on IAP check with API Key auth. Explicitly disable for screenshots-only lane.

🤖 Generated with [Claude Code](https://claude.com/claude-code)