### PR TITLE
chore(ios): bump version to 1.0.1 for IAP resubmission

### DIFF
--- a/app.json
+++ b/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Repolog",
     "slug": "repolog",
-    "version": "1.0.0",
+    "version": "1.0.1",
     "orientation": "portrait",
     "icon": "./assets/images/icon.png",
     "scheme": "repolog",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "repolog",
   "main": "expo-router/entry",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "engines": {
     "node": ">=20.0.0"
   },


### PR DESCRIPTION
## Why

App Store Connect から IAP が Apple ガイドライン **2.1(b) — App Completeness** で返却されました。理由は「**the required binary was not submitted**」。初回 IAP は必ず新しいバイナリと同時に提出する必要があるが、1.0.0 リリース時に 3 product が attach されていなかった。

結果として、リリース版 Paywall で月額/年額/買い切りすべての価格が "Unavailable" 表示、購入ボタンが disabled。

- RevenueCat Dashboard 側: Offering / Packages / Entitlement すべて正常
- ビジネス契約 / 納税 / 銀行: すべて有効
- 残る作業は **binary + IAP の同時再提出** のみ

## What

- `app.json`: version `1.0.0` → `1.0.1`
- `package.json`: version `1.0.0` → `1.0.1`

buildNumber は EAS `appVersionSource: remote` + `autoIncrement: true` により自動採番。

## How

マージ後:
1. `gh workflow run build-ios-testflight.yml --ref main` で iOS ビルド + TestFlight 提出をトリガー
2. ASC > Repolog > 1.0.1 バージョン画面で 3 IAP product を attach、`repolog_pro_lifetime` に Privacy Policy URL 入力、What's New 記入
3. バイナリ + IAP を同時に審査へ提出

## Test Plan

- [x] `pnpm lint` — 0 errors
- [x] `pnpm type-check` — pass
- [ ] GitHub Actions `Build iOS & Submit to TestFlight` 成功
- [ ] ASC の 1.0.1 バージョンにビルド番号が表示される
- [ ] Apple 審査通過後、実機 (新規 DL) で Paywall に価格表示

🤖 Generated with [Claude Code](https://claude.com/claude-code)